### PR TITLE
feat: exclusion markers

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -66,13 +66,10 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "indoc",
  "log",
  "markdown",
  "mdast_util_to_markdown",
  "regex",
- "rstest",
- "serde",
  "serde_json",
  "test-log",
 ]
@@ -111,83 +108,6 @@ dependencies = [
  "jiff",
  "log",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -307,12 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,15 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -399,61 +304,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rstest"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -497,12 +351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
-
-[[package]]
 name = "syn"
 version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,23 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -727,12 +558,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -12,12 +12,230 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
+ "indoc",
+ "log",
  "markdown",
+ "mdast_util_to_markdown",
+ "regex",
+ "rstest",
+ "serde",
+ "serde_json",
+ "test-log",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
  "regex",
 ]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "markdown"
@@ -25,7 +243,27 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
 dependencies = [
+ "serde",
  "unicode-id",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "mdast_util_to_markdown"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4847e9e76278c5ad9a101a017c2798226c6fe1094dfb8e6338efd97e9a5bc55"
+dependencies = [
+ "markdown",
+ "regex",
 ]
 
 [[package]]
@@ -35,6 +273,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,8 +362,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -54,8 +383,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -64,7 +399,340 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "syn"
+version = "2.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-id"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,18 +5,15 @@ edition = "2024"
 
 [dependencies]
 regex = "1.11.1"
-markdown = {version="1.0.0", features=["serde"]}
+markdown = { version = "1.0.0", features = ["serde"] }
 mdast_util_to_markdown = "0.0.2"
 log = "0.4.27"
 serde_json = "1.0.140"
-serde = { version = "1.0.219", features = ["derive"] }
 env_logger = "0.11.8"
 test-log = "0.2.17"
-rstest = "0.25.0"
 
 [dev-dependencies]
 env_logger = "0.11.8"
 regex = "1.11.1"
 markdown = "1.0.0"
 test-log = "0.2.17"
-indoc = "2.0.6"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,4 +5,18 @@ edition = "2024"
 
 [dependencies]
 regex = "1.11.1"
+markdown = {version="1.0.0", features=["serde"]}
+mdast_util_to_markdown = "0.0.2"
+log = "0.4.27"
+serde_json = "1.0.140"
+serde = { version = "1.0.219", features = ["derive"] }
+env_logger = "0.11.8"
+test-log = "0.2.17"
+rstest = "0.25.0"
+
+[dev-dependencies]
+env_logger = "0.11.8"
+regex = "1.11.1"
 markdown = "1.0.0"
+test-log = "0.2.17"
+indoc = "2.0.6"

--- a/backend/src/parser.rs
+++ b/backend/src/parser.rs
@@ -1,4 +1,5 @@
 pub mod code_block;
+pub mod exclude;
 
 use crate::errors::ParserError;
 use code_block::CodeBlock;

--- a/backend/src/parser/exclude/mod.rs
+++ b/backend/src/parser/exclude/mod.rs
@@ -1,0 +1,160 @@
+use log::debug;
+use markdown::mdast::{List, Node, Paragraph, Text};
+use markdown::unist::{Point, Position};
+
+#[cfg(test)]
+mod test;
+
+fn get_ast(input: &str) -> Node {
+    markdown::to_mdast(input, &markdown::ParseOptions::mdx()).unwrap()
+}
+
+const EXCLUDE_PARAGRAPH_MARKER: &str = "%p";
+const EXCLUDE_LINE_MARKER: &str = "%";
+const EXCLUDE_LIST_MARKER: &str = "%l";
+const EXCLUDE_LIST_ITEM_MARKER: &str = "%i";
+
+fn process_list(list_node: &List) -> Option<List> {
+    let mut new_list = List {
+        children: vec![],
+        position: None,
+        ordered: false,
+        start: None,
+        spread: false,
+    };
+    'list_items_loop: for item in &list_node.children {
+        if let Node::ListItem(list_item) = item {
+            let mut new_item = list_item.clone();
+            for child in list_item.children.iter() {
+                if let Node::Paragraph(p) = child {
+                    let first_child = p.children.iter().next();
+                    if let Some(Node::Text(t)) = first_child {
+                        let first_line = t.value.lines().next();
+                        if let Some(line) = first_line {
+                            if line.ends_with(EXCLUDE_LIST_MARKER) {
+                                return None;
+                            }
+                            if line.ends_with(EXCLUDE_LIST_ITEM_MARKER) {
+                                continue 'list_items_loop; // Exclude this list item completely, no need to process the rest of its children
+                            }
+                        }
+                    }
+                }
+            }
+            new_item.children = process_children(&list_item.children);
+            new_list.children.push(Node::ListItem(new_item));
+        }
+    }
+    return Some(new_list);
+}
+
+fn process_paragraph(paragraph: &Paragraph) -> Option<Paragraph> {
+    let mut new_paragraph = Paragraph {
+        children: vec![],
+        position: None,
+    };
+    for child in &paragraph.children {
+        if let Node::Text(text) = child {
+            let mut lines = text.value.lines();
+            let first_line = lines.next();
+            if let Some(line) = first_line {
+                // debug!("First line {}", line);
+                if line.ends_with(EXCLUDE_PARAGRAPH_MARKER) {
+                    // debug!("Excluding this paragraph: {}", line);
+                    return None;
+                }
+            }
+            let mut content = String::new();
+            for line in text.value.lines() {
+                if line.ends_with(EXCLUDE_LINE_MARKER) {
+                    // debug!("Excluding this line: {}", line);
+                    continue;
+                } else {
+                    content.push_str((line.to_string() + "\n").as_str());
+                }
+            }
+            let new_text = Text {
+                value: content.trim().to_string(),
+                position: text.position.clone(),
+            };
+            if !new_text.value.is_empty() {
+                new_paragraph.children.push(Node::Text(new_text));
+            }
+        }
+    }
+
+    return Some(new_paragraph);
+}
+
+fn process_text(text: &Text) -> Option<Text> {
+    let mut new_text = Text {
+        value: String::new(),
+        position: None,
+    };
+    let mut line_start_offset = vec![0];
+    for (i, char) in text.value.char_indices() {
+        if (char == '\n') || (char == '\r') {
+            line_start_offset.push(i + 1);
+        }
+    }
+    line_start_offset.push(text.position.clone().unwrap().end.offset);
+    for (i, line) in text.value.lines().enumerate() {
+        if (line.ends_with(" %")) {
+            continue;
+        }
+        new_text.value.push_str(line);
+    }
+    return Some(new_text);
+}
+
+fn process_children(children: &Vec<Node>) -> Vec<Node> {
+    let mut new_children: Vec<Node> = vec![];
+    for child in children {
+        match child {
+            Node::Paragraph(p) => {
+                debug!("Paragraph: {}", serde_json::to_string_pretty(&p).unwrap());
+                let new_paragraph = process_paragraph(p);
+                if let Some(np) = new_paragraph {
+                    debug!(
+                        "Processed Paragraph: {}",
+                        serde_json::to_string_pretty(&np).unwrap()
+                    );
+                    new_children.push(Node::Paragraph(np));
+                }
+            }
+            Node::Code(code) => {
+                if let Some(meta_str) = &code.meta {
+                    if meta_str.ends_with("%") {
+                        continue;
+                    }
+                }
+                new_children.push(child.clone());
+            }
+            Node::List(list) => {
+                let new_list = process_list(&list);
+                if let Some(nl) = new_list {
+                    // debug!("Processed List: {:?}", nl);
+                    new_children.push(Node::List(nl));
+                } else {
+                    // debug!("List was excluded");
+                    continue;
+                }
+            }
+            _ => {
+                // For all other nodes, push them as they are
+                new_children.push(child.clone());
+            }
+        }
+    }
+    return new_children;
+}
+
+fn exclude_from_markdown(input_str: &str) -> Node {
+    let mut new_children: Vec<Node> = vec![];
+    let mut mdast = get_ast(input_str);
+    new_children = process_children(mdast.children().unwrap());
+    if let Node::Root(r) = &mut mdast {
+        r.children = new_children;
+    }
+    return mdast;
+}

--- a/backend/src/parser/exclude/mod.rs
+++ b/backend/src/parser/exclude/mod.rs
@@ -86,27 +86,6 @@ fn process_paragraph(paragraph: &Paragraph) -> Option<Paragraph> {
     return Some(new_paragraph);
 }
 
-fn process_text(text: &Text) -> Option<Text> {
-    let mut new_text = Text {
-        value: String::new(),
-        position: None,
-    };
-    let mut line_start_offset = vec![0];
-    for (i, char) in text.value.char_indices() {
-        if (char == '\n') || (char == '\r') {
-            line_start_offset.push(i + 1);
-        }
-    }
-    line_start_offset.push(text.position.clone().unwrap().end.offset);
-    for (i, line) in text.value.lines().enumerate() {
-        if (line.ends_with(" %")) {
-            continue;
-        }
-        new_text.value.push_str(line);
-    }
-    return Some(new_text);
-}
-
 fn process_children(children: &Vec<Node>) -> Vec<Node> {
     let mut new_children: Vec<Node> = vec![];
     for child in children {

--- a/backend/src/parser/exclude/test.rs
+++ b/backend/src/parser/exclude/test.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn test_exclusions_file(file: &str) {
+        let file_path = Path::new(file!()); // "tests/my_test.rs"
+        let dir = file_path.parent().unwrap().join("test_files");
+        let in_file = dir.join(format!("{file}-in.md"));
+        let out_file = dir.join(format!("{file}-out.md"));
+        let input = std::fs::read_to_string(&in_file)
+            .expect(format!("Failed to read file {}", in_file.display()).as_str());
+        let expected_output = std::fs::read_to_string(&out_file)
+            .expect(format!("Failed to read {}", out_file.display()).as_str());
+
+        let ast_with_exclusions = exclude_from_markdown(input.as_str());
+        let actual_output = mdast_util_to_markdown::to_markdown(&ast_with_exclusions)
+            .expect("Failed to convert to markdown");
+        let x = actual_output.trim();
+        assert_eq!(
+            expected_output, x,
+            "Output does not match expected for {file}"
+        );
+    }
+
+    #[test_log::test]
+    fn test_exclusions_1() {
+        test_exclusions_file("test_1")
+    }
+    #[test_log::test]
+    fn test_exclusions_2() {
+        test_exclusions_file("test_2")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_3() {
+        test_exclusions_file("test_3")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_4() {
+        test_exclusions_file("test_4")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_5() {
+        test_exclusions_file("test_5")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_6() {
+        test_exclusions_file("test_6")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_7() {
+        test_exclusions_file("test_7")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_8() {
+        test_exclusions_file("test_8")
+    }
+
+    #[test_log::test]
+    fn test_exclusions_9() {
+        test_exclusions_file("test_9")
+    }
+}

--- a/backend/src/parser/exclude/test_files/test_1-in.md
+++ b/backend/src/parser/exclude/test_files/test_1-in.md
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.

--- a/backend/src/parser/exclude/test_files/test_1-out.md
+++ b/backend/src/parser/exclude/test_files/test_1-out.md
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.

--- a/backend/src/parser/exclude/test_files/test_2-in.md
+++ b/backend/src/parser/exclude/test_files/test_2-in.md
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie  %p
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.

--- a/backend/src/parser/exclude/test_files/test_3-in.md
+++ b/backend/src/parser/exclude/test_files/test_3-in.md
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie %
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.

--- a/backend/src/parser/exclude/test_files/test_3-out.md
+++ b/backend/src/parser/exclude/test_files/test_3-out.md
@@ -1,0 +1,1 @@
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.

--- a/backend/src/parser/exclude/test_files/test_4-in.md
+++ b/backend/src/parser/exclude/test_files/test_4-in.md
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum mauris ac magna maximus, in tempor 
+eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod. Etiam dignissim arcu at sapien auctor, %
+et consequat lacus lobortis.
+
+Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer %
+fringilla est a scelerisque euismod. Quisque in bibendum risus.

--- a/backend/src/parser/exclude/test_files/test_4-out.md
+++ b/backend/src/parser/exclude/test_files/test_4-out.md
@@ -1,0 +1,4 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum mauris ac magna maximus, in tempor
+et consequat lacus lobortis.
+
+fringilla est a scelerisque euismod. Quisque in bibendum risus.

--- a/backend/src/parser/exclude/test_files/test_5-in.md
+++ b/backend/src/parser/exclude/test_files/test_5-in.md
@@ -1,0 +1,6 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor %i 
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod.
+* Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis. %i
+* Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer
+fringilla est a scelerisque euismod. Quisque in bibendum risus.

--- a/backend/src/parser/exclude/test_files/test_5-out.md
+++ b/backend/src/parser/exclude/test_files/test_5-out.md
@@ -1,0 +1,3 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer
+  fringilla est a scelerisque euismod. Quisque in bibendum risus.

--- a/backend/src/parser/exclude/test_files/test_6-in.md
+++ b/backend/src/parser/exclude/test_files/test_6-in.md
@@ -1,0 +1,9 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod. %
+* Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+* Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer %p
+fringilla est a scelerisque euismod. Quisque in bibendum risus.
+
+  Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo. 
+In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_6-out.md
+++ b/backend/src/parser/exclude/test_files/test_6-out.md
@@ -1,0 +1,5 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+* Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+* Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo.
+  In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_7-in.md
+++ b/backend/src/parser/exclude/test_files/test_7-in.md
@@ -1,0 +1,9 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod.
+  * Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis. %l
+  * Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer
+fringilla est a scelerisque euismod. Quisque in bibendum risus.
+
+  Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo. 
+In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_7-out.md
+++ b/backend/src/parser/exclude/test_files/test_7-out.md
@@ -1,0 +1,6 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod.
+
+  Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo.
+  In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_8-in.md
+++ b/backend/src/parser/exclude/test_files/test_8-in.md
@@ -1,0 +1,9 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod.
+  * Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+  * Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero. Integer %i
+fringilla est a scelerisque euismod. Quisque in bibendum risus.
+
+  Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo.
+In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_8-out.md
+++ b/backend/src/parser/exclude/test_files/test_8-out.md
@@ -1,0 +1,8 @@
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+* Vestibulum fermentum mauris ac magna maximus, in tempor
+  eros scelerisque. Phasellus rhoncus purus vitae enim consequat euismod.
+
+  * Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+
+  Maecenas eu ligula sed lorem tincidunt lacinia vitae vel justo.
+  In ullamcorper diam ac massa volutpat, non semper erat lacinia.

--- a/backend/src/parser/exclude/test_files/test_9-in.md
+++ b/backend/src/parser/exclude/test_files/test_9-in.md
@@ -1,0 +1,11 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.
+
+```python %
+print("Some code")
+print("Hello world")
+```
+
+* Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+* Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero.
+* Integer fringilla est a scelerisque euismod. Quisque in bibendum risus.

--- a/backend/src/parser/exclude/test_files/test_9-out.md
+++ b/backend/src/parser/exclude/test_files/test_9-out.md
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at cursus lorem. Donec in urna a ante molestie
+sagittis. Nunc tortor leo, sollicitudin sed dui eu, venenatis vulputate nibh.
+
+* Etiam dignissim arcu at sapien auctor, et consequat lacus lobortis.
+* Duis nunc orci, convallis vitae lacus cursus, pellentesque pretium libero.
+* Integer fringilla est a scelerisque euismod. Quisque in bibendum risus.


### PR DESCRIPTION
**Motivation**

Exclude content from the markdown according to the exclusion markers (`%, %p, %l, %i`).

**Description**

Removes (in the case of full paragraph, full list item, full list, or code block exclusion)  or modifies (in case of single lines within a paragraph) the nodes of the AST according to the markers, building a new AST, and afterwards generating the "clean" markdown.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #45

