### PR TITLE
refactor: use a hashmap for code_blocks

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -1,14 +1,14 @@
 use std::fmt;
 pub enum ParserError {
     InvalidInput(String),
-    UnexpectedToken(String), // currently not used
+    CodeBlockError(String),
 }
 
 impl fmt::Display for ParserError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ParserError::InvalidInput(msg) => write!(f, "Invalid input: {}", msg),
-            ParserError::UnexpectedToken(token) => write!(f, "Unexpected token: {}", token),
+            ParserError::CodeBlockError(msg) => write!(f, "Error parsing Code Block: {}", msg),
         }
     }
 }
@@ -17,7 +17,7 @@ impl fmt::Debug for ParserError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ParserError::InvalidInput(msg) => write!(f, "Invalid input: {}", msg),
-            ParserError::UnexpectedToken(token) => write!(f, "Unexpected token: {}", token),
+            ParserError::CodeBlockError(msg) => write!(f, "Error parsing Code Block: {}", msg),
         }
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     };
 
     // Tangle blocks
-    let Ok(output) = tangle_block(&tangle_args.target_block, &blocks)
+    let Ok(output) = tangle_block(&tangle_args.target_block, blocks)
         .inspect_err(|e| println!("Error tangling blocks: {e}"))
     else {
         return;

--- a/backend/src/parser.rs
+++ b/backend/src/parser.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_input_no_blocks() {
+    fn test_parse_code_blocks_no_blocks() {
         let input = r#"
         This is just plain text.
         No code blocks here.
@@ -80,7 +80,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_input_block_and_text() {
+    fn test_parse_code_blocks_block_and_text() {
         let input = r#"
         This is some text.
         ```python hello
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_input_malformed_blocks() {
+    fn test_parse_code_blocks_malformed_blocks() {
         let input = r#"
         ```python hello_python
         print("Hello, world!")
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_input_multiple_blocks() {
+    fn test_parse_code_blocks_multiple_blocks() {
         let input = r#"
 ```python block_1
 print("Block 1")
@@ -173,5 +173,49 @@ print("Hello, world!")
             vec!["block1".to_string(), "block2".to_string()]
         );
         assert_eq!(blocks.get("block3").unwrap().language, Language::Python);
+    }
+
+    #[test]
+    fn test_parse_code_blocks_without_tag() {
+        let input = r#"
+```python
+print("Hello, world!")
+```"#;
+        let blocks = parse_code_blocks(input.to_string()).unwrap();
+        assert_eq!(blocks.len(), 1);
+        let block = blocks.get("2").unwrap(); // Default tag based on line number
+        assert_eq!(block.code.trim(), r#"print("Hello, world!")"#);
+        assert_eq!(block.tag, "2".to_string());
+        assert!(block.imports.is_empty());
+        assert_eq!(block.language, Language::Python);
+    }
+
+    #[test]
+    fn test_parse_code_blocks_various_blocks() {
+        let input = r#"
+```python
+print("Hello, world!")
+```
+```javascript
+console.log("Hello, world!");
+```
+```Rust rust
+println!("Hello, world!");
+```"#;
+        let blocks = parse_code_blocks(input.to_string()).unwrap();
+
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(
+            blocks.get("2").unwrap().code.trim(),
+            r#"print("Hello, world!")"#
+        );
+        assert_eq!(
+            blocks.get("5").unwrap().code.trim(),
+            r#"console.log("Hello, world!");"#
+        );
+        assert_eq!(
+            blocks.get("rust").unwrap().code.trim(),
+            r#"println!("Hello, world!");"#
+        );
     }
 }

--- a/backend/src/parser.rs
+++ b/backend/src/parser.rs
@@ -1,14 +1,13 @@
 pub mod code_block;
 pub mod slides;
 
-use std::collections::HashMap;
-
 use crate::errors::ParserError;
 use code_block::CodeBlock;
 use markdown::{
     ParseOptions,
     mdast::{Code, Node},
 };
+use std::collections::HashMap;
 
 pub fn parse_blocks_from_file(file_path: &str) -> Result<HashMap<String, CodeBlock>, ParserError> {
     // Read the file content

--- a/backend/src/parser/code_block.rs
+++ b/backend/src/parser/code_block.rs
@@ -46,6 +46,8 @@ impl CodeBlock {
         Self::new(Language::Unknown, code, "".to_string(), Vec::new())
     }
 
+    /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.
+    /// If the tag is not specified in the code block, it defaults to the line number of the code block.
     pub fn from_code_node(code_block: Code) -> Result<Self, ParserError> {
         let language = Language::parse_language(&code_block.lang.unwrap_or_default());
         let (tag, imports) = Self::parse_metadata(&code_block.meta.unwrap_or_default());
@@ -97,8 +99,8 @@ mod tests {
 
     #[test]
     fn test_parse_metadata_with_use() {
-        let metadata = "use=[block1,block2] tag1".to_string();
-        let (tag, imports) = CodeBlock::parse_metadata(&metadata);
+        let metadata = "use=[block1,block2] tag1";
+        let (tag, imports) = CodeBlock::parse_metadata(metadata);
         assert_eq!(tag, Some("tag1".to_string()));
         assert_eq!(imports, vec!["block1".to_string(), "block2".to_string()]);
     }

--- a/backend/src/tangle.rs
+++ b/backend/src/tangle.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{errors::TangleError, parser::code_block::CodeBlock};
 
 pub fn tangle_blocks(blocks: Vec<CodeBlock>) -> String {
@@ -9,23 +11,26 @@ pub fn tangle_blocks(blocks: Vec<CodeBlock>) -> String {
     tangle
 }
 
-pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
-    // Search block
-    let code_block = blocks
-        .iter()
-        .find(|b| b.tag.clone().unwrap_or_default() == block)
-        .ok_or(TangleError::BlockNotFound(block.into()))?;
+pub fn tangle_block(
+    target_block: &str,
+    blocks: HashMap<String, CodeBlock>,
+) -> Result<String, TangleError> {
+    // Get target_code_block
+    let target_code_block = blocks
+        .get(target_block)
+        .ok_or(TangleError::BlockNotFound(target_block.into()))?;
 
-    // Search imported blocks
-    let imported_blocks: Vec<CodeBlock> = blocks
+    // Get imported blocks
+    let imported_blocks: Vec<CodeBlock> = target_code_block
+        .imports
         .iter()
-        .filter(|b| {
-            code_block
-                .imports
-                .contains(&b.tag.clone().unwrap_or_default())
+        .map(|import| {
+            blocks
+                .get(import)
+                .cloned()
+                .ok_or(TangleError::BlockNotFound(import.clone()))
         })
-        .cloned()
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Tangle imports
     let mut tangle = String::new();
@@ -36,7 +41,7 @@ pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleE
         tangle.push('\n');
     }
 
-    add_main_code_block(code_block, &mut tangle);
+    add_main_code_block(target_code_block, &mut tangle);
 
     Ok(tangle)
 }

--- a/backend/src/tangle.rs
+++ b/backend/src/tangle.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use crate::{errors::TangleError, parser::code_block::CodeBlock};
+use std::collections::HashMap;
 
 pub fn tangle_blocks(blocks: Vec<CodeBlock>) -> String {
     let mut tangle = String::new();


### PR DESCRIPTION
**Motivation**

`parse_code_blocks` returns a `Vec<CodeBlocks>`.

**Description**

- Changes the return type of `parse_code_blocks` to `HashMap<String, CodeBlock>`, where the key is the block's tag.
- A default tag is assigned to blocks that do not have a tag in their metadata. Currently, the default tag is their position in the file.


Closes #11 

