### PR TITLE
feat: block execution

### DIFF
--- a/backend/cli.md
+++ b/backend/cli.md
@@ -1,6 +1,20 @@
 # Using the Backend CLI
 
-Use the `backend` CLI `tangle` command to tangle code blocks from your `.md` files.
+```
+Usage: backend <COMMAND>
+
+Commands:
+  tangle   Tangle a specific code block from a markdown file and export to a file
+  exclude  Exclude parts with % markers from input markdown file
+  execute  Execute a specific code block from a markdown file and read its output
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+Use the `backend` CLI `tangle` subcommand to tangle code blocks from your `.md` files. The `execute` subcommand allows you execute a given supported code block. The relevant build tools or interpreters must be available on your $PATH.
 
 ### ✅ Tangle
 
@@ -8,7 +22,7 @@ Use the `backend` CLI `tangle` command to tangle code blocks from your `.md` fil
 backend tangle --input-file-path <INPUT_FILE_PATH> --output-dir <OUTPUT_DIR> --target-block <TARGET_BLOCK>
 ```
 
-### 🔧 Options
+#### 🔧 Options
 
 | Option                     | Description                                                                 |
 |---------------------------|-----------------------------------------------------------------------------|
@@ -19,6 +33,22 @@ backend tangle --input-file-path <INPUT_FILE_PATH> --output-dir <OUTPUT_DIR> --t
 | `-V`, `--version`         | Show the CLI version.                                                        |
 
 ---
+
+### ✅ Execute
+
+```sh
+backend execute --input-file-path <INPUT_FILE_PATH> --target-block <TARGET_BLOCK>
+```
+
+| Option                     | Description                                                                 |
+|---------------------------|-----------------------------------------------------------------------------|
+| `--input-file-path`       | Path to the input Markdown file.                                            |
+| `--target-block`          | Name (tag) of the code block to execute.                                     |
+| `-h`, `--help`            | Show help message.                                                           |
+| `-V`, `--version`         | Show the CLI version.                                                        |
+
+---
+
 
 ## 📄 Example Input File
 
@@ -73,6 +103,12 @@ int main() {
 }
 
 ````
+
+## 💻 Executing a Block
+
+You can execute a given bare block of code in your markdown file using the `execute` subcommand and passing the name of the desired block. Interpreted languages are run as-is by the relevant interpreter found in your $PATH variable, while compiled languages like C often need a defined entry point. Blocks from these languages get wrapped in a `main` subroutine/function or equivalent notion and compiled before executing.  
+The standard output of the resulting program is captured and shown.
+
 
 ---
 

--- a/backend/cli.md
+++ b/backend/cli.md
@@ -49,6 +49,19 @@ backend execute --input-file-path <INPUT_FILE_PATH> --target-block <TARGET_BLOCK
 
 ---
 
+### Exclude
+
+```sh
+backend exclude --input-file-path <INPUT_FILE_PATH> --output-file-path <OUTPUT_FILE_PATH>
+```
+
+| Option                     | Description                                                                 |
+|---------------------------|-----------------------------------------------------------------------------|
+| `--input-file-path`       | Path to the input Markdown file.                                            |
+| `--output-file-path`          | Path to the file where the output will be saved.                         |
+| `-h`, `--help`            | Show help message.                                                           |
+| `-V`, `--version`         | Show the CLI version.                                                        |
+
 
 ## 📄 Example Input File
 
@@ -111,6 +124,8 @@ The standard output of the resulting program is captured and shown.
 
 
 ---
+
+
 
 ## 📌 Tips
 

--- a/backend/src/cli.rs
+++ b/backend/src/cli.rs
@@ -14,6 +14,7 @@ pub enum Commands {
     Tangle(TangleArgs),
     #[command(about = "Exclude parts with % markers from input markdown file")]
     Exclude(ExcludeArgs),
+    #[command(about = "Execute a specific code block from a markdown file and read its output")]
     Execute(ExecuteArgs),
 }
 
@@ -72,8 +73,8 @@ pub struct ExecuteArgs {
     #[arg(
         long,
         value_name = "TARGET_BLOCK",
-        help = "Tag of the code block to tangle.",
-        help_heading = "Tangle Args",
+        help = "Tag of the code block to execute.",
+        help_heading = "Execute Args",
         env = "TARGET_BLOCK"
     )]
     pub target_block: String,

--- a/backend/src/cli.rs
+++ b/backend/src/cli.rs
@@ -14,6 +14,7 @@ pub enum Commands {
     Tangle(TangleArgs),
     #[command(about = "Exclude parts with % markers from input markdown file")]
     Exclude(ExcludeArgs),
+    Execute(ExecuteArgs),
 }
 
 #[derive(Args, Debug)]
@@ -62,4 +63,18 @@ pub struct ExcludeArgs {
         env = "OUTPUT_FILE_PATH"
     )]
     pub output_file_path: String,
+}
+
+#[derive(Args)]
+pub struct ExecuteArgs {
+    #[command(flatten)]
+    pub general: GeneralArgs,
+    #[arg(
+        long,
+        value_name = "TARGET_BLOCK",
+        help = "Tag of the code block to tangle.",
+        help_heading = "Tangle Args",
+        env = "TARGET_BLOCK"
+    )]
+    pub target_block: String,
 }

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -24,15 +24,19 @@ impl fmt::Debug for ParserError {
 
 pub enum TangleError {
     BlockNotFound(String),
-    LanguageNotSupported,
+    LanguageNotSupported(String),
 }
 
 impl fmt::Display for TangleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TangleError::BlockNotFound(msg) => write!(f, "Block tag not found: {}", msg),
-            TangleError::LanguageNotSupported => {
-                write!(f, "Programming language not supported for execution:")
+            TangleError::LanguageNotSupported(lang) => {
+                write!(
+                    f,
+                    "Programming language not supported for execution: {}",
+                    lang
+                )
             }
         }
     }
@@ -42,8 +46,12 @@ impl fmt::Debug for TangleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TangleError::BlockNotFound(msg) => write!(f, "Block tag not found: {}", msg),
-            TangleError::LanguageNotSupported => {
-                write!(f, "Programming language not supported for execution")
+            TangleError::LanguageNotSupported(lang) => {
+                write!(
+                    f,
+                    "Programming language not supported for execution: {}",
+                    lang
+                )
             }
         }
     }

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -24,12 +24,16 @@ impl fmt::Debug for ParserError {
 
 pub enum TangleError {
     BlockNotFound(String),
+    LanguageNotSupported,
 }
 
 impl fmt::Display for TangleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TangleError::BlockNotFound(msg) => write!(f, "Block tag not found: {}", msg),
+            TangleError::LanguageNotSupported => {
+                write!(f, "Programming language not supported for execution:")
+            }
         }
     }
 }
@@ -38,6 +42,9 @@ impl fmt::Debug for TangleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TangleError::BlockNotFound(msg) => write!(f, "Block tag not found: {}", msg),
+            TangleError::LanguageNotSupported => {
+                write!(f, "Programming language not supported for execution")
+            }
         }
     }
 }

--- a/backend/src/file_generation.rs
+++ b/backend/src/file_generation.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::process::{Command, Output, Stdio};
+use std::{env, fs::write, path::PathBuf};
+
+pub fn write_file(contents: String, name: &str, ext: &str) -> std::path::PathBuf {
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+    let tmp_dir = current_dir.join("tmp");
+    if !tmp_dir.exists() {
+        fs::create_dir_all(&tmp_dir).expect("Failed to create temp directory");
+    }
+    // Create the file path using the target block name
+    let c_file = tmp_dir.join(format!("{}.{}", name, ext));
+
+    // Write the tangled output to the C file
+    write(&c_file, contents).expect("Failed to write C file");
+    c_file
+}
+
+fn run_binary(binary_path: &str) -> Output {
+    Command::new(binary_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to execute binary")
+}
+
+pub fn execute_c_file(source_file_path: PathBuf) -> Output {
+    let output_binary = source_file_path.with_extension("");
+
+    // Compile the C program
+    // TODO: make compilation configurable at runtime
+    let compile_status = Command::new("gcc")
+        .arg(&source_file_path)
+        .arg("-o")
+        .arg(&output_binary)
+        .status()
+        .expect("Failed to start gcc");
+
+    if !compile_status.success() {
+        eprintln!("Failed to compile C program.");
+        std::process::exit(1);
+    }
+
+    let binary = output_binary.to_str().unwrap();
+
+    // Step 2: Run the compiled C binary and capture output
+    run_binary(binary)
+}
+
+pub fn execute_python_file(source_file_path: PathBuf) -> Output {
+    // Run the Python script and capture output
+    Command::new("python3")
+        .arg(source_file_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to execute Python script")
+}
+
+// fn execute_rust_file(source_file_path: PathBuf) -> Output {
+//     todo!()
+// }
+
+//TODO: tests (probably require mocking or to be integration type tests)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod errors;
+pub mod file_generation;
 pub mod parser;
 pub mod tangle;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,8 +3,6 @@ use backend::parser::exclude::exclude_from_markdown;
 use backend::tangle as tg;
 use backend::{cli::Cli, parser::parse_blocks_from_file, tangle::tangle_block};
 use clap::Parser;
-use std::fs;
-use std::process::{Command, Stdio};
 use std::{
     fs::write,
     path::{Path, PathBuf},
@@ -65,43 +63,8 @@ fn handle_execute_command(execute_args: backend::cli::ExecuteArgs) {
         return;
     };
 
-    // Step 1: Compile the C program
-    // Create a temporary directory in the current working directory
-    let current_dir = std::env::current_dir().expect("Failed to get current directory");
-    let tmp_dir = current_dir.join("tmp");
-    if !tmp_dir.exists() {
-        fs::create_dir_all(&tmp_dir).expect("Failed to create temp directory");
-    }
-
-    // Create the C file path using the target block name
-    let c_file = tmp_dir.join(format!("{}.c", execute_args.target_block));
-    let output_binary = tmp_dir.join(format!("{}", execute_args.target_block));
-
-    // Write the tangled output to the C file
-    fs::write(&c_file, output).expect("Failed to write C file");
-
-    // Compile the C program
-    let compile_status = Command::new("gcc")
-        .arg(&c_file)
-        .arg("-o")
-        .arg(&output_binary)
-        .status()
-        .expect("Failed to start gcc");
-
-    if !compile_status.success() {
-        eprintln!("Failed to compile C program.");
-        std::process::exit(1);
-    }
-
-    // Step 2: Run the compiled C binary and capture output
-    let output = Command::new(output_binary)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("Failed to execute C program");
-
-    println!("C stdout:\n{}", String::from_utf8_lossy(&output.stdout));
-    eprintln!("C stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    println!("stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("stderr:\n{}", String::from_utf8_lossy(&output.stderr));
 }
 
 fn main() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,10 @@
 use backend::cli::{Commands, ExcludeArgs, TangleArgs};
 use backend::parser::exclude::exclude_from_markdown;
+use backend::tangle as tg;
 use backend::{cli::Cli, parser::parse_blocks_from_file, tangle::tangle_block};
 use clap::Parser;
+use std::fs;
+use std::process::{Command, Stdio};
 use std::{
     fs::write,
     path::{Path, PathBuf},
@@ -45,6 +48,62 @@ fn handle_exclude_command(exclude_args: ExcludeArgs) {
     };
 }
 
+fn handle_execute_command(execute_args: backend::cli::ExecuteArgs) {
+    // Parse blocks from the input file
+    let blocks = match parse_blocks_from_file(&execute_args.general.input_file_path) {
+        Ok(blocks) => blocks,
+        Err(e) => {
+            println!("Error parsing blocks: {}", e);
+            return;
+        }
+    };
+
+    // Tangle blocks
+    let Ok(output) = tg::tangle_execute_block(&execute_args.target_block, &blocks)
+        .inspect_err(|e| println!("Error tangling blocks: {e}"))
+    else {
+        return;
+    };
+
+    // Step 1: Compile the C program
+    // Create a temporary directory in the current working directory
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let tmp_dir = current_dir.join("tmp");
+    if !tmp_dir.exists() {
+        fs::create_dir_all(&tmp_dir).expect("Failed to create temp directory");
+    }
+
+    // Create the C file path using the target block name
+    let c_file = tmp_dir.join(format!("{}.c", execute_args.target_block));
+    let output_binary = tmp_dir.join(format!("{}", execute_args.target_block));
+
+    // Write the tangled output to the C file
+    fs::write(&c_file, output).expect("Failed to write C file");
+
+    // Compile the C program
+    let compile_status = Command::new("gcc")
+        .arg(&c_file)
+        .arg("-o")
+        .arg(&output_binary)
+        .status()
+        .expect("Failed to start gcc");
+
+    if !compile_status.success() {
+        eprintln!("Failed to compile C program.");
+        std::process::exit(1);
+    }
+
+    // Step 2: Run the compiled C binary and capture output
+    let output = Command::new(output_binary)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to execute C program");
+
+    println!("C stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("C stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -52,9 +111,11 @@ fn main() {
         Commands::Tangle(args) => {
             handle_tangle_command(args);
         }
-
         Commands::Exclude(args) => {
             handle_exclude_command(args);
+        }
+        Commands::Execute(args) => {
+            handle_execute_command(args);
         }
     }
 }

--- a/backend/src/tangle.rs
+++ b/backend/src/tangle.rs
@@ -39,12 +39,22 @@ fn find_block_by_tag<'a, 'b>(
         .ok_or(TangleError::BlockNotFound(tag.into()))
 }
 
-pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
+pub fn tangle_execute_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
     // Search block
     let code_block = find_block_by_tag(blocks, block)?;
     let mut tangle = String::new();
 
     add_main_code_block(code_block, &mut tangle);
+    let tangle = add_imports(code_block, blocks, tangle);
+
+    Ok(tangle)
+}
+
+pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
+    // Search block
+    let code_block = find_block_by_tag(blocks, block)?;
+    let tangle = String::new();
+
     let tangle = add_imports(code_block, blocks, tangle);
 
     Ok(tangle)
@@ -59,7 +69,6 @@ pub fn add_main_code_block(code_block: &CodeBlock, tangle: &mut String) {
     tangle.push_str("    return 0;");
     tangle.push_str("\n}\n");
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/tangle.rs
+++ b/backend/src/tangle.rs
@@ -1,4 +1,5 @@
 use crate::{errors::TangleError, parser::code_block::CodeBlock};
+use std::process;
 
 pub fn tangle_blocks(blocks: Vec<CodeBlock>) -> String {
     let mut tangle = String::new();
@@ -29,25 +30,36 @@ fn add_imports(block: &CodeBlock, blocks: &[CodeBlock], source_code: String) -> 
     accum_block
 }
 
-fn find_block_by_tag<'a, 'b>(
-    blocks: &'a [CodeBlock],
-    tag: &'b str,
-) -> Result<&'a CodeBlock, TangleError> {
+fn find_block_by_tag<'a>(blocks: &'a [CodeBlock], tag: &str) -> Result<&'a CodeBlock, TangleError> {
     blocks
         .iter()
         .find(|b| b.tag.clone().unwrap_or_default() == tag)
         .ok_or(TangleError::BlockNotFound(tag.into()))
 }
 
-pub fn tangle_execute_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
+pub fn tangle_execute_block(
+    block: &str,
+    blocks: &[CodeBlock],
+) -> Result<process::Output, TangleError> {
     // Search block
     let code_block = find_block_by_tag(blocks, block)?;
-    let mut tangle = String::new();
 
-    add_executable_wrapper_block(code_block, &mut tangle)?;
-    let tangle = add_imports(code_block, blocks, tangle);
-
-    Ok(tangle)
+    match code_block.language {
+        crate::parser::code_block::Language::Python => {
+            let code = add_imports(code_block, blocks, code_block.code.clone());
+            let file = crate::file_generation::write_file(code, block, "py");
+            Ok(crate::file_generation::execute_python_file(file))
+        }
+        crate::parser::code_block::Language::C => {
+            let mut tangle = String::new();
+            add_c_wrapper(code_block, &mut tangle);
+            let code = add_imports(code_block, blocks, tangle);
+            let file = crate::file_generation::write_file(code, block, "c");
+            Ok(crate::file_generation::execute_c_file(file))
+        }
+        crate::parser::code_block::Language::Rust => todo!(),
+        _ => Err(TangleError::LanguageNotSupported("some lang".into())),
+    }
 }
 
 pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleError> {
@@ -60,30 +72,6 @@ pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleE
     Ok(tangle)
 }
 
-// TODO: this should use a template depending on the language
-// TODO: handle indentation
-pub fn add_executable_wrapper_block(
-    code_block: &CodeBlock,
-    tangle: &mut String,
-) -> Result<(), TangleError> {
-    match code_block.language {
-        crate::parser::code_block::Language::Python => Ok(add_python_wrapper(code_block, tangle)),
-        crate::parser::code_block::Language::Rust => Ok(add_rust_wrapper(code_block, tangle)),
-        crate::parser::code_block::Language::C => Ok(add_c_wrapper(code_block, tangle)),
-        _ => {
-            return Err(TangleError::LanguageNotSupported);
-        }
-    }
-}
-
-fn add_python_wrapper(code_block: &CodeBlock, tangle: &str) {
-    todo!()
-}
-
-fn add_rust_wrapper(code_block: &CodeBlock, tangle: &str) {
-    todo!()
-}
-
 fn add_c_wrapper(code_block: &CodeBlock, tangle: &mut String) {
     tangle.push_str("int main() {\n");
     tangle.push_str(&code_block.code);
@@ -94,6 +82,8 @@ fn add_c_wrapper(code_block: &CodeBlock, tangle: &mut String) {
 
 #[cfg(test)]
 mod tests {
+    use crate::parser::code_block::Language;
+
     use super::*;
 
     #[test]
@@ -116,5 +106,41 @@ mod tests {
         )];
         let tangle = tangle_blocks(blocks);
         assert_eq!(tangle, "print('Hello, world!')\n");
+    }
+
+    #[test]
+    fn test_tangle_execute_block_python() {
+        let blocks = vec![CodeBlock::new(
+            Language::Python,
+            "print('Hello, world!')".to_string(),
+            Some("print_block".to_string()),
+            vec![],
+        )];
+        let tangle = tangle_execute_block("print_block", &blocks);
+        assert!(tangle.is_ok());
+        let tangle = tangle.unwrap();
+        assert_eq!(String::from_utf8_lossy(&tangle.stdout), "Hello, world!\n");
+    }
+
+    #[test]
+    fn test_tangle_execute_block_c() {
+        let blocks = vec![
+            CodeBlock::new(
+                Language::C,
+                "#include <stdio.h>\n".to_string(),
+                Some("imports".to_string()),
+                vec![],
+            ),
+            CodeBlock::new(
+                Language::C,
+                "printf(\"Hello, world!\");".to_string(),
+                Some("print_block".to_string()),
+                vec!["imports".to_string()],
+            ),
+        ];
+        let tangle = tangle_execute_block("print_block", &blocks);
+        assert!(tangle.is_ok());
+        let tangle = tangle.unwrap();
+        assert_eq!(String::from_utf8_lossy(&tangle.stdout), "Hello, world!");
     }
 }

--- a/backend/src/tangle.rs
+++ b/backend/src/tangle.rs
@@ -44,7 +44,7 @@ pub fn tangle_execute_block(block: &str, blocks: &[CodeBlock]) -> Result<String,
     let code_block = find_block_by_tag(blocks, block)?;
     let mut tangle = String::new();
 
-    add_main_code_block(code_block, &mut tangle);
+    add_executable_wrapper_block(code_block, &mut tangle)?;
     let tangle = add_imports(code_block, blocks, tangle);
 
     Ok(tangle)
@@ -62,13 +62,36 @@ pub fn tangle_block(block: &str, blocks: &[CodeBlock]) -> Result<String, TangleE
 
 // TODO: this should use a template depending on the language
 // TODO: handle indentation
-pub fn add_main_code_block(code_block: &CodeBlock, tangle: &mut String) {
+pub fn add_executable_wrapper_block(
+    code_block: &CodeBlock,
+    tangle: &mut String,
+) -> Result<(), TangleError> {
+    match code_block.language {
+        crate::parser::code_block::Language::Python => Ok(add_python_wrapper(code_block, tangle)),
+        crate::parser::code_block::Language::Rust => Ok(add_rust_wrapper(code_block, tangle)),
+        crate::parser::code_block::Language::C => Ok(add_c_wrapper(code_block, tangle)),
+        _ => {
+            return Err(TangleError::LanguageNotSupported);
+        }
+    }
+}
+
+fn add_python_wrapper(code_block: &CodeBlock, tangle: &str) {
+    todo!()
+}
+
+fn add_rust_wrapper(code_block: &CodeBlock, tangle: &str) {
+    todo!()
+}
+
+fn add_c_wrapper(code_block: &CodeBlock, tangle: &mut String) {
     tangle.push_str("int main() {\n");
     tangle.push_str(&code_block.code);
     tangle.push('\n');
     tangle.push_str("    return 0;");
     tangle.push_str("\n}\n");
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/test_data/test_file.md
+++ b/backend/test_data/test_file.md
@@ -16,8 +16,17 @@ void greet(const char* name) {
 }
 ```
 
+execute a simple block:
+```c use=[headers] example
+int x = 2 + 3;
+printf("%d\n", x);
+```
+
 Define main block `run`:
 
 ```c use=[headers,helper] main_block
+int main() {
     greet("Tangle User");
+    return 0;
+}
 ```

--- a/backend/test_data/test_file.md
+++ b/backend/test_data/test_file.md
@@ -22,6 +22,14 @@ int x = 2 + 3;
 printf("%d\n", x);
 ```
 
+execute a python block:
+```python monty
+a = 'SPAM'
+for i in range(4):
+    print(a)
+```
+
+
 Define main block `run`:
 
 ```c use=[headers,helper] main_block


### PR DESCRIPTION
Added new subcommand for executing bare code in a code block. Currently only c code via a main function wrapper. Closes #48