### PR TITLE
refactor: handle execution errors

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -45,3 +45,47 @@ impl fmt::Debug for TangleError {
         }
     }
 }
+
+pub enum ExecutionError {
+    ParseError(ParserError),
+    TangleError(TangleError),
+    WriteError(String),
+    UnsupportedLanguage(String),
+    InternalError(String),
+}
+
+impl fmt::Display for ExecutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutionError::ParseError(e) => write!(f, "Error parsing blocks: {}", e),
+            ExecutionError::TangleError(e) => write!(f, "Error tangling block: {}", e),
+            ExecutionError::WriteError(msg) => write!(f, "Error writing file: {}", msg),
+            ExecutionError::UnsupportedLanguage(msg) => write!(f, "Unsupported language: {}", msg),
+            ExecutionError::InternalError(msg) => write!(f, "Internal error: {}", msg),
+        }
+    }
+}
+
+impl fmt::Debug for ExecutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutionError::ParseError(e) => write!(f, "Error parsing blocks: {}", e),
+            ExecutionError::TangleError(e) => write!(f, "Error tangling block: {}", e),
+            ExecutionError::WriteError(msg) => write!(f, "Error writing file: {}", msg),
+            ExecutionError::UnsupportedLanguage(msg) => write!(f, "Unsupported language: {}", msg),
+            ExecutionError::InternalError(msg) => write!(f, "Internal error: {}", msg),
+        }
+    }
+}
+
+impl From<ParserError> for ExecutionError {
+    fn from(error: ParserError) -> Self {
+        ExecutionError::ParseError(error)
+    }
+}
+
+impl From<TangleError> for ExecutionError {
+    fn from(error: TangleError) -> Self {
+        ExecutionError::TangleError(error)
+    }
+}

--- a/backend/src/execution.rs
+++ b/backend/src/execution.rs
@@ -1,13 +1,61 @@
+use crate::errors::ExecutionError;
 use crate::parser::code_block::Language;
 use crate::parser::parse_blocks_from_file;
 use crate::tangle::tangle_block;
-use std::io;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
+use std::{fmt, io};
 use std::{fs::write, path::PathBuf};
 
+pub struct ExecutionOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl fmt::Display for ExecutionOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.stderr.is_empty() {
+            write!(f, "{}", self.stdout)
+        } else {
+            write!(f, "STDERR:\n{}", self.stderr)
+        }
+    }
+}
+
+pub fn execute(
+    input_file_path: &str,
+    target_block: &str,
+) -> Result<ExecutionOutput, ExecutionError> {
+    // Parse blocks from the input file
+    let blocks = parse_blocks_from_file(input_file_path)?;
+
+    // Tangle blocks
+    let (output, lang) = tangle_block(target_block, blocks, true)?;
+
+    // Write the output to a file
+    let block_file_path = write_file(output, target_block, &lang)
+        .map_err(|e| ExecutionError::WriteError(e.to_string()))?;
+
+    let handles = match lang {
+        crate::parser::code_block::Language::C => crate::execution::execute_c_file(block_file_path),
+        crate::parser::code_block::Language::Python => {
+            crate::execution::execute_python_file(block_file_path)
+        }
+        other => {
+            return Err(ExecutionError::UnsupportedLanguage(other.to_string()));
+        }
+    };
+
+    let output = ExecutionOutput {
+        stdout: String::from_utf8_lossy(&handles.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&handles.stderr).to_string(),
+    };
+
+    Ok(output)
+}
+
 /// Writes the contents to a file to a `tmp` directory in the current directory.
-pub fn write_file(contents: String, name: &str, lang: &Language) -> io::Result<std::path::PathBuf> {
+fn write_file(contents: String, name: &str, lang: &Language) -> io::Result<std::path::PathBuf> {
     let current_dir = env::current_dir()?;
     let tmp_dir = current_dir.join("tmp");
     if !tmp_dir.exists() {
@@ -26,18 +74,9 @@ pub fn write_file(contents: String, name: &str, lang: &Language) -> io::Result<s
     io::Result::Ok(source_file)
 }
 
-/// Runs a binary file and captures its output.
-fn run_binary(binary_path: &str) -> Output {
-    Command::new(binary_path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("Failed to execute binary")
-}
-
 /// Executes a C file by compiling it and then running the resulting binary.
 /// This function assumes that the `gcc` compiler is available in the system's PATH.
-pub fn execute_c_file(source_file_path: PathBuf) -> Output {
+fn execute_c_file(source_file_path: PathBuf) -> Output {
     let output_binary = source_file_path.with_extension("");
 
     // Compile the C program
@@ -60,9 +99,18 @@ pub fn execute_c_file(source_file_path: PathBuf) -> Output {
     run_binary(binary)
 }
 
+/// Runs a binary file and captures its output.
+fn run_binary(binary_path: &str) -> Output {
+    Command::new(binary_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to execute binary")
+}
+
 /// Executes a Python file by running it with the Python interpreter.
 /// This function assumes that the Python interpreter is available in the system's PATH.
-pub fn execute_python_file(source_file_path: PathBuf) -> Output {
+fn execute_python_file(source_file_path: PathBuf) -> Output {
     // Run the Python script and capture output
     Command::new("python3")
         .arg(source_file_path)
@@ -75,45 +123,5 @@ pub fn execute_python_file(source_file_path: PathBuf) -> Output {
 // fn execute_rust_file(source_file_path: PathBuf) -> Output {
 //     todo!()
 // }
-
-pub fn execute(input_file_path: &str, target_block: &str) -> String {
-    // Parse blocks from the input file
-    let blocks = match parse_blocks_from_file(input_file_path) {
-        Ok(blocks) => blocks,
-        Err(e) => {
-            println!("Error parsing blocks: {}", e);
-            return "Error".to_string();
-        }
-    };
-
-    // Tangle blocks
-    let Ok((output, lang)) = tangle_block(target_block, blocks, true)
-        .inspect_err(|e| println!("Error tangling blocks: {e}"))
-    else {
-        return "Error".to_string();
-    };
-
-    // Write the output to a file
-    let Ok(block_file_path) = write_file(output, target_block, &lang).inspect_err(|e| {
-        println!("Error writing to file: {e}");
-    }) else {
-        return "Error".to_string();
-    };
-
-    let handles = match lang {
-        crate::parser::code_block::Language::C => crate::execution::execute_c_file(block_file_path),
-        crate::parser::code_block::Language::Python => {
-            crate::execution::execute_python_file(block_file_path)
-        }
-        _ => {
-            println!("Unsupported language");
-            return "Error".to_string();
-        }
-    };
-
-    println!("stdout:\n{}", String::from_utf8_lossy(&handles.stdout));
-    eprintln!("stderr:\n{}", String::from_utf8_lossy(&handles.stderr));
-    String::from_utf8_lossy(&handles.stdout).to_string()
-}
 
 //TODO: tests (probably require mocking or to be integration type tests)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -56,7 +56,7 @@ fn handle_execute_command(execute_args: backend::cli::ExecuteArgs) {
             eprintln!("Error executing block: {}", e);
             std::process::exit(1);
         }
-        Ok(output) => println!("{}", output),
+        Ok(output) => println!("{output:?}"),
     }
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -48,10 +48,13 @@ fn handle_exclude_command(exclude_args: ExcludeArgs) {
 }
 
 fn handle_execute_command(execute_args: backend::cli::ExecuteArgs) {
-    let _ = execution::execute(
+    if let Err(e) = execution::execute(
         &execute_args.general.input_file_path,
         &execute_args.target_block,
-    );
+    ) {
+        eprintln!("Error executing block: {}", e);
+        std::process::exit(1);
+    }
 }
 
 fn main() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -48,12 +48,15 @@ fn handle_exclude_command(exclude_args: ExcludeArgs) {
 }
 
 fn handle_execute_command(execute_args: backend::cli::ExecuteArgs) {
-    if let Err(e) = execution::execute(
+    match execution::execute(
         &execute_args.general.input_file_path,
         &execute_args.target_block,
     ) {
-        eprintln!("Error executing block: {}", e);
-        std::process::exit(1);
+        Err(e) => {
+            eprintln!("Error executing block: {}", e);
+            std::process::exit(1);
+        }
+        Ok(output) => println!("{}", output),
     }
 }
 

--- a/backend/src/parser/code_block.rs
+++ b/backend/src/parser/code_block.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::errors::ParserError;
 use markdown::mdast::Code;
 use regex::Regex;
@@ -7,7 +9,7 @@ const USE_REGEX: &str = r"use=\[([^\]]*)\]";
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum Language {
-    Unknown,
+    Unknown(String),
     Python,
     Rust,
     C,
@@ -19,7 +21,18 @@ impl Language {
             "python" => Language::Python,
             "rust" => Language::Rust,
             "c" => Language::C,
-            _ => Language::Unknown,
+            other => Language::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Language::Python => write!(f, "Python"),
+            Language::Rust => write!(f, "Rust"),
+            Language::C => write!(f, "C"),
+            Language::Unknown(lang) => write!(f, "{}", lang),
         }
     }
 }
@@ -51,7 +64,13 @@ impl CodeBlock {
     }
 
     pub fn new_with_code(code: String) -> Self {
-        Self::new(Language::Unknown, code, "".to_string(), Vec::new(), 0)
+        Self::new(
+            Language::Unknown("".to_string()),
+            code,
+            "".to_string(),
+            Vec::new(),
+            0,
+        )
     }
 
     /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -39,9 +39,13 @@ fn tanglit_parse_blocks(raw_markdown: &str) -> Vec<CodeBlock> {
 fn tanglit_execute_block(raw_markdown: &str, block_name: &str) -> String {
     // write raw_markdown to a file
     let data = raw_markdown;
-    let file_name = "output.md";
-    fs::write(file_name, data).map_err(|e| format!("Error writing file: {}", e));
-    backend::execution::execute(file_name, block_name)
+    let file_name = "output.md"; // TODO: use a temporary file instead
+    fs::write(file_name, data).map_err(|e| format!("Error writing file: {}", e)); // TODO: handle error properly
+
+    match backend::execution::execute(file_name, block_name) {
+        Ok(output) => output.to_string(),
+        Err(e) => format!("Error executing block: {}", e),
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -43,7 +43,7 @@ fn tanglit_execute_block(raw_markdown: &str, block_name: &str) -> String {
     fs::write(file_name, data).map_err(|e| format!("Error writing file: {}", e)); // TODO: handle error properly
 
     match backend::execution::execute(file_name, block_name) {
-        Ok(output) => output.to_string(),
+        Ok(output) => format!("{output:?}"),
         Err(e) => format!("Error executing block: {}", e),
     }
 }


### PR DESCRIPTION
**Motivation**

We are not handling errors properly in our `execute()` function.

**Description**

- Changes the return type of `execute()` to `Result<std::process:Output,ExecutionError>`.
- ~~Introduces the `ExecutionOutput` struct to hold the output of the executed program.~~
- Handles ~~`ExecutionOutput`~~ `std::process:Output` from both the CLI and the frontend.
- Makes all auxiliary functions in the `execution` module private, leaving only `execute()` as public.
- Reorganizes the functions within the `execution` module.

Now the frontend displays an error if the execution of a block fails:

<img width="584" alt="image" src="https://github.com/user-attachments/assets/30c2c826-982d-4e38-b53b-f4ac0e7f078e" />


Closes #56 

