### PR TITLE
Feat: runtime configuration

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,7 +12,9 @@ serde_json = "1.0.140"
 clap = { version = "4.5.39", features = ["derive", "env"] }
 serde = { version = "1.0.219", features = ["derive"] }
 once_cell = "1.21.3"
+directories = "6.0.0"
 
 [dev-dependencies]
 env_logger = "0.11.8"
+temp-env = "0.3.6"
 test-log = "0.2.17"

--- a/backend/src/configuration.rs
+++ b/backend/src/configuration.rs
@@ -1,0 +1,13 @@
+mod user;
+
+use std::io;
+use user::create_configuration_dirs;
+
+pub use user::{get_default_config_dir, get_default_temp_dir};
+
+/// Creates and initializes the default configuration directories.
+pub fn init_configuration() -> io::Result<()> {
+    create_configuration_dirs()?;
+    // any additional initialization logic should go here
+    Ok(())
+}

--- a/backend/src/configuration/user.rs
+++ b/backend/src/configuration/user.rs
@@ -1,0 +1,67 @@
+use std::{fs, io, path::PathBuf, sync::OnceLock};
+
+use directories;
+
+const DEFAULT_PROJECT_NAME: &str = "tanglit";
+static DEFAULT_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
+static DEFAULT_TEMP_DIR: OnceLock<PathBuf> = OnceLock::new();
+const TEMP_DIR_ENVVAR: &str = "TANGLIT_TEMP_DIR";
+const CONFIG_DIR_ENVVAR: &str = "TANGLIT_CONFIG_DIR";
+
+/// Returns the default configuration directory path, either from the environment variable
+/// or from the default project directory structure.
+/// If the environment variable is not set, it defaults to a platform-specific config directory
+/// under the user's home directory.
+/// If it cannot be determined, it falls back to the current directory in a `.tanglit` subdirectory.
+pub fn get_default_config_dir() -> &'static PathBuf {
+    DEFAULT_CONFIG_DIR.get_or_init(|| {
+        std::env::var(CONFIG_DIR_ENVVAR)
+            .map(|v| PathBuf::from(v).join(DEFAULT_PROJECT_NAME))
+            .unwrap_or_else(|_| {
+                directories::ProjectDirs::from("", "", DEFAULT_PROJECT_NAME)
+                    .map(|dirs| dirs.config_dir().to_path_buf())
+                    .unwrap_or_else(|| {
+                        PathBuf::from(".").join(format!(".{}", DEFAULT_PROJECT_NAME))
+                    })
+            })
+    })
+}
+/// Returns the default temporary directory path used for any intermediate files generated during execution.
+/// It uses the `TANGLIT_TEMP_DIR` environment variable if set, otherwise it
+/// defaults to the system's temporary directory with a subdirectory named after the project.
+/// It also follows the implementation of rust's `std::env::temp_dir()`, meaning that `TMPDIR` is also
+/// a valid environment variable to use in unix systems
+pub fn get_default_temp_dir() -> &'static PathBuf {
+    DEFAULT_TEMP_DIR.get_or_init(|| {
+        std::env::var(TEMP_DIR_ENVVAR)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::temp_dir().join(DEFAULT_PROJECT_NAME))
+    })
+}
+
+pub fn create_configuration_dirs() -> io::Result<()> {
+    let temp_dir = get_default_temp_dir();
+    fs::create_dir_all(temp_dir)?;
+    let config_dir = get_default_config_dir();
+    fs::create_dir_all(config_dir)?;
+    Ok(())
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_default_config_dir() {
+        use temp_env::with_var;
+        let random_dir = "/tmp/tanglit_test_config";
+        with_var(super::CONFIG_DIR_ENVVAR, Some(random_dir), || {
+            let config_dir = super::get_default_config_dir();
+            assert_eq!(
+                config_dir.as_path(),
+                PathBuf::from(random_dir)
+                    .join(DEFAULT_PROJECT_NAME)
+                    .as_path()
+            );
+        });
+    }
+}

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -2,9 +2,8 @@ mod error;
 mod parser;
 mod tangle;
 
-pub use crate::doc::error::DocError;
 use crate::doc::parser::{ast_to_markdown, parse_code_blocks_from_ast, parse_from_string};
-pub use crate::doc::tangle::TangleError;
+pub use error::DocError;
 use markdown::mdast::Node;
 pub use parser::ParserError;
 pub use parser::code_block::{CodeBlock, Language};
@@ -13,6 +12,7 @@ pub use parser::slides::Slide;
 use parser::slides::parse_slides_from_ast;
 use std::collections::HashMap;
 pub use tangle::CodeBlocksDoc;
+pub use tangle::TangleError;
 use tangle::from_codeblocks;
 
 pub struct TanglitDoc {

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -12,7 +12,8 @@ use parser::exclude::exclude_from_ast;
 pub use parser::slides::Slide;
 use parser::slides::parse_slides_from_ast;
 use std::collections::HashMap;
-use tangle::tangle_block;
+pub use tangle::CodeBlocksDoc;
+use tangle::from_codeblocks;
 
 pub struct TanglitDoc {
     raw_markdown: String,
@@ -34,7 +35,7 @@ impl TanglitDoc {
         Self::new_from_string(&input)
     }
 
-    pub fn parse_blocks(&self) -> Result<HashMap<String, CodeBlock>, DocError> {
+    fn parse_blocks(&self) -> Result<HashMap<String, CodeBlock>, DocError> {
         Ok(parse_code_blocks_from_ast(&self.ast)?)
     }
 
@@ -60,12 +61,8 @@ impl TanglitDoc {
         Ok(ast_to_markdown(&ast_with_exclusions)?)
     }
 
-    pub fn tangle_block(
-        &self,
-        target_block: &str,
-        add_wrapper: bool,
-    ) -> Result<(String, Language), DocError> {
+    pub fn tangle(&self) -> Result<CodeBlocksDoc, DocError> {
         let blocks = self.parse_blocks()?;
-        Ok(tangle_block(target_block, blocks, add_wrapper)?)
+        Ok(from_codeblocks(blocks))
     }
 }

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -38,6 +38,19 @@ impl TanglitDoc {
         Ok(parse_code_blocks_from_ast(&self.ast)?)
     }
 
+    pub fn get_block(
+        &self,
+        block_name: &str,
+        blocks: &HashMap<String, CodeBlock>,
+    ) -> Result<CodeBlock, DocError> {
+        blocks
+            .get(block_name)
+            .cloned()
+            .ok_or(DocError::TangleError(TangleError::BlockNotFound(
+                block_name.to_string(),
+            )))
+    }
+
     pub fn parse_slides(&self) -> Vec<Slide> {
         parse_slides_from_ast(&self.ast, &self.raw_markdown)
     }

--- a/backend/src/execution.rs
+++ b/backend/src/execution.rs
@@ -1,35 +1,16 @@
+use crate::doc::CodeBlocksDoc;
 use crate::doc::DocError;
-use crate::doc::Language;
+use crate::doc::TangleError;
 use crate::doc::TanglitDoc;
+use crate::doc::{CodeBlock, Language};
 use crate::errors::ExecutionError;
-use crate::execution;
 use std::io;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
 use std::{fs::write, path::PathBuf};
 
-pub fn execute(doc: &TanglitDoc, target_block: &str) -> Result<Output, ExecutionError> {
-    let blocks = doc.tangle()?;
-
-    // Tangle blocks
-    let (output, lang) = blocks
-        .tangle_block(target_block, true)
-        .map_err(DocError::TangleError)?;
-
-    // Write the output to a file
-    let block_file_path = write_file(output, target_block, &lang)
-        .map_err(|e| ExecutionError::WriteError(e.to_string()))?;
-
-    let output = match lang {
-        Language::C => execution::execute_c_file(block_file_path),
-        Language::Python => execution::execute_python_file(block_file_path),
-        other => {
-            return Err(ExecutionError::UnsupportedLanguage(other.to_string()));
-        }
-    };
-
-    Ok(output)
-}
+const DEFAULT_INDENT_SIZE: usize = 4;
+const DEFAULT_INDENT_CHARACTER: char = ' ';
 
 /// Writes the contents to a file to a `tmp` directory in the current directory.
 fn write_file(contents: String, name: &str, lang: &Language) -> io::Result<std::path::PathBuf> {
@@ -97,8 +78,219 @@ fn execute_python_file(source_file_path: PathBuf) -> Output {
         .expect("Failed to execute Python script")
 }
 
+/// Sets indentation for each line in the code.
+///
+/// # Arguments
+/// * `code` - A mutable reference to the string containing the code to indent
+/// * `indent_size` - Optional number of indentation characters to use per level (defaults to 4)
+/// * `indent_character` - Optional character to use for indentation (defaults to space)
+fn set_indentation(code: &mut String, indent_size: Option<usize>, indent_character: Option<char>) {
+    let indent_str = indent_character
+        .unwrap_or(DEFAULT_INDENT_CHARACTER)
+        .to_string()
+        .repeat(indent_size.unwrap_or(DEFAULT_INDENT_SIZE));
+
+    *code = std::mem::take(code)
+        .lines()
+        .map(|line| format!("{}{}\n", indent_str, line))
+        .collect::<String>();
+}
+
+fn add_c_wrapper(code: &str, tangle: &mut String) {
+    let mut code = code.to_string();
+    code.push('\n');
+    code.push_str("return 0;");
+    set_indentation(&mut code, None, None);
+
+    tangle.push_str("int main() {\n");
+    tangle.push_str(&code);
+    // tangle.push('\n');
+    tangle.push_str("}\n");
+}
+
+fn add_python_wrapper(code: &str, tangle: &mut String) {
+    // For Python, we don't need to add a wrapper
+    // but we can still set indentation
+    let mut code = code.to_string();
+    set_indentation(&mut code, None, None);
+    tangle.push_str("if __name__ == '__main__':\n");
+    tangle.push_str(&code);
+}
+
+// fn add_rust_wrapper(code: &str, tangle: &mut String) {
+//     let mut code = code.clone();
+//     set_indentation(&mut code, None, None);
+//     tangle.push_str("fn main() {\n");
+//     tangle.push_str(&code);
+//     tangle.push('\n');
+//     tangle.push_str("}\n");
+// }
+
 // fn execute_rust_file(source_file_path: PathBuf) -> Output {
 //     todo!()
 // }
 
-//TODO: tests (probably require mocking or to be integration type tests)
+/// Tangles code in a given codeblock, wraps it in a language-specific wrapper
+/// and adds any imported blocks. Indentation is applied.
+fn make_executable_code(
+    code_block: &CodeBlock,
+    blocks: &CodeBlocksDoc,
+) -> Result<String, ExecutionError> {
+    // Tangle blocks
+    let mut output = String::new();
+
+    for import in &code_block.imports {
+        if let Some(import_block) = blocks.get_block(import) {
+            // Tangle the imported block
+            let import_output = blocks
+                .tangle_codeblock(import_block)
+                .map_err(|e| ExecutionError::from(DocError::from(e)))?;
+            // Append the import output to the main output
+            output.push_str(&import_output);
+            output.push('\n');
+        } else {
+            return Err(ExecutionError::InternalError(format!(
+                "Import '{}' not found in blocks",
+                import
+            )));
+        }
+    }
+
+    let code = blocks
+        .tangle_codeblock(code_block)
+        .map_err(|e| ExecutionError::from(DocError::from(e)))?;
+
+    match &code_block.language {
+        Language::C => add_c_wrapper(&code, &mut output),
+        Language::Python => {
+            add_python_wrapper(&code, &mut output);
+        }
+        Language::Unknown(lang) => return Err(ExecutionError::UnsupportedLanguage(lang.clone())),
+        Language::Rust => return Err(ExecutionError::UnsupportedLanguage("Rust".into())),
+    }
+
+    Ok(output)
+}
+
+/// Executes a code block by tangling it and adding necessary wrappers to make it executable.
+/// Prints both the resulting stdout and sterr from the execution and returns the stdout as a String.
+/// # Arguments
+/// * `doc` - A reference to the TanglitDoc containing the code blocks
+/// * `target_block` - The name of the target code block to execute
+/// # Returns
+/// * Result containing the stdout of the execution or an error if something goes wrong
+pub fn execute(doc: &TanglitDoc, target_block: &str) -> Result<Output, ExecutionError> {
+    let blocks = doc.tangle()?;
+
+    let block =
+        blocks
+            .get_block(target_block)
+            .ok_or(DocError::from(TangleError::BlockNotFound(
+                target_block.to_string(),
+            )))?;
+
+    // create the executable source code
+    let output = make_executable_code(block, &blocks)?;
+
+    // Write the output to a file
+    let block_file_path = write_file(output, target_block, &block.language)
+        .map_err(|e| ExecutionError::WriteError(e.to_string()))?;
+
+    let handles = match &block.language {
+        Language::C => crate::execution::execute_c_file(block_file_path),
+        Language::Python => crate::execution::execute_python_file(block_file_path),
+        Language::Rust => {
+            return Err(ExecutionError::UnsupportedLanguage("Rust".into()));
+        }
+        Language::Unknown(lang) => {
+            return Err(ExecutionError::UnsupportedLanguage(lang.clone()));
+        }
+    };
+
+    Ok(handles)
+}
+
+//TODO: execution tests (probably require mocking or to be integration type tests)
+
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_make_executable_code_c() {
+        let mut blocks = HashMap::new();
+        let main = CodeBlock::new(
+            Language::C,
+            "@[x]\nprintf(\"Hello, world!: %d\",x);".to_string(),
+            "main".to_string(),
+            vec!["io".to_string()],
+            0,
+        );
+        blocks.insert("main".to_string(), main.clone());
+        blocks.insert(
+            "io".to_string(),
+            CodeBlock::new(
+                Language::C,
+                "#include <stdio.h>".to_string(),
+                "io".to_string(),
+                vec![],
+                0,
+            ),
+        );
+        blocks.insert(
+            "x".to_string(),
+            CodeBlock::new(
+                Language::C,
+                "int x;\nx = 42;".to_string(),
+                "x".to_string(),
+                vec![],
+                0,
+            ),
+        );
+        let tangle = make_executable_code(&main, &CodeBlocksDoc::from_codeblocks(blocks)).unwrap();
+        assert_eq!(
+            tangle,
+            "#include <stdio.h>\nint main() {\n    int x;\n    x = 42;\n    printf(\"Hello, world!: %d\",x);\n    return 0;\n}\n"
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_make_executable_code_python() {
+        let mut blocks = HashMap::new();
+        let main = CodeBlock::new(
+            Language::Python,
+            "@[x]\nprint(f\"Hello, world!: {x}\")".to_string(),
+            "main".to_string(),
+            vec!["io".to_string()],
+            0,
+        );
+        blocks.insert("main".to_string(), main.clone());
+        blocks.insert(
+            "io".to_string(),
+            CodeBlock::new(
+                Language::Python,
+                "import sys".to_string(),
+                "io".to_string(),
+                vec![],
+                0,
+            ),
+        );
+        blocks.insert(
+            "x".to_string(),
+            CodeBlock::new(
+                Language::Python,
+                "x = 42".to_string(),
+                "x".to_string(),
+                vec![],
+                0,
+            ),
+        );
+        let tangle = make_executable_code(&main, &CodeBlocksDoc::from_codeblocks(blocks)).unwrap();
+        assert_eq!(
+            tangle,
+            "import sys\nif __name__ == '__main__':\n    x = 42\n    print(f\"Hello, world!: {x}\")\n".to_string()
+        );
+    }
+}

--- a/backend/src/execution.rs
+++ b/backend/src/execution.rs
@@ -1,3 +1,4 @@
+use crate::configuration::get_default_temp_dir;
 use crate::doc::CodeBlocksDoc;
 use crate::doc::DocError;
 use crate::doc::TangleError;
@@ -6,7 +7,6 @@ use crate::doc::{CodeBlock, Language};
 use crate::errors::ExecutionError;
 use std::io;
 use std::process::{Command, Output, Stdio};
-use std::{env, fs};
 use std::{fs::write, path::PathBuf};
 
 const DEFAULT_INDENT_SIZE: usize = 4;
@@ -14,11 +14,8 @@ const DEFAULT_INDENT_CHARACTER: char = ' ';
 
 /// Writes the contents to a file to a `tmp` directory in the current directory.
 fn write_file(contents: String, name: &str, lang: &Language) -> io::Result<std::path::PathBuf> {
-    let current_dir = env::current_dir()?;
-    let tmp_dir = current_dir.join("tmp");
-    if !tmp_dir.exists() {
-        fs::create_dir_all(&tmp_dir)?;
-    }
+    let tmp_dir = get_default_temp_dir();
+
     // Create the file path using the target block name
     let ext = match lang {
         Language::C => "c",

--- a/backend/src/execution.rs
+++ b/backend/src/execution.rs
@@ -1,3 +1,4 @@
+use crate::doc::DocError;
 use crate::doc::Language;
 use crate::doc::TanglitDoc;
 use crate::errors::ExecutionError;
@@ -8,8 +9,12 @@ use std::{env, fs};
 use std::{fs::write, path::PathBuf};
 
 pub fn execute(doc: &TanglitDoc, target_block: &str) -> Result<Output, ExecutionError> {
+    let blocks = doc.tangle()?;
+
     // Tangle blocks
-    let (output, lang) = doc.tangle_block(target_block, true)?;
+    let (output, lang) = blocks
+        .tangle_block(target_block, true)
+        .map_err(DocError::TangleError)?;
 
     // Write the output to a file
     let block_file_path = write_file(output, target_block, &lang)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod configuration;
 pub mod doc;
 pub mod errors;
 pub mod execution;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use backend::cli::{Commands, ExcludeArgs, TangleArgs};
-use backend::doc::{Language, TanglitDoc};
+use backend::doc::{DocError, Language, TanglitDoc};
 use backend::errors::ExecutionError;
 use backend::errors::ExecutionError::WriteError;
 use backend::{cli::Cli, execution};
@@ -12,7 +12,11 @@ use std::{
 fn handle_tangle_command(tangle_args: TangleArgs) -> Result<String, ExecutionError> {
     let input_file_path = tangle_args.general.input_file_path;
     let doc = TanglitDoc::new_from_file(&input_file_path)?;
-    let (output, lang) = doc.tangle_block(&tangle_args.target_block, true)?;
+    // Tangle the document
+    let blocks = doc.tangle()?;
+    let (output, lang) = blocks
+        .tangle_block(&tangle_args.target_block, true)
+        .map_err(DocError::TangleError)?;
 
     let output_file_path =
         get_output_file_path(&tangle_args.output_dir, &tangle_args.target_block, lang);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use backend::cli::{Commands, ExcludeArgs, TangleArgs};
-use backend::doc::{DocError, Language, TanglitDoc};
+use backend::doc::{DocError, Language, TangleError, TanglitDoc};
 use backend::errors::ExecutionError;
 use backend::errors::ExecutionError::WriteError;
 use backend::{cli::Cli, execution};
@@ -12,12 +12,21 @@ use std::{
 fn handle_tangle_command(tangle_args: TangleArgs) -> Result<String, ExecutionError> {
     let input_file_path = tangle_args.general.input_file_path;
     let doc = TanglitDoc::new_from_file(&input_file_path)?;
+
     // Tangle the document
     let blocks = doc.tangle()?;
-    let (output, lang) = blocks
-        .tangle_block(&tangle_args.target_block, true)
-        .map_err(DocError::TangleError)?;
+    let block = blocks
+        .get_block(&tangle_args.target_block)
+        .ok_or(ExecutionError::from(DocError::from(
+            TangleError::BlockNotFound(tangle_args.target_block.clone()),
+        )))?;
+    let output = blocks
+        .tangle_block(&tangle_args.target_block)
+        .map_err(DocError::from)?;
 
+    let lang = block.language.clone();
+
+    // Write the output to a file
     let output_file_path =
         get_output_file_path(&tangle_args.output_dir, &tangle_args.target_block, lang);
     match write(&output_file_path, output) {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,5 @@
 use backend::cli::{Commands, ExcludeArgs, TangleArgs};
+use backend::configuration::init_configuration;
 use backend::doc::{DocError, Language, TangleError, TanglitDoc};
 use backend::errors::ExecutionError;
 use backend::errors::ExecutionError::WriteError;
@@ -66,6 +67,11 @@ fn handle_execute_command(
 
 fn main() {
     let cli = Cli::parse();
+
+    if let Err(e) = init_configuration() {
+        eprintln!("Configuration error: {}", e);
+        std::process::exit(1);
+    }
 
     let result = match cli.command {
         Commands::Tangle(args) => handle_tangle_command(args),

--- a/backend/test_data/test_file.md
+++ b/backend/test_data/test_file.md
@@ -25,7 +25,9 @@ for i in range(4):
 Define main block `run`:
 
 ```c use=[headers,helper] main_block
+int main(){
     greet("Tangle User");
+}
 ```
 
 ---
@@ -37,10 +39,15 @@ Define a variable:
 ```c config
 const char* language = "C";
 ```
+or even just a plain value:
+```c a_value
+42
+```
 
-Import and use the variable using a macro:
+Import and use the variable using macros:
 
 ```c variable_user use=[headers]
-    @[config]
-    printf("This program is written in %s.\n", language);
+@[config]
+printf("This program is written in %s.\n", language);
+printf("and the meaning of life is %d\n", @[a_value]);
 ```


### PR DESCRIPTION
**Motivation**

Aspects of the app should be configurable at runtime by the user. This requires saving and loading configuration from a known location at runtime.

**Description**

This pull request handles determining the appropriate configuration locations for a given platform (mainly \*nix). For most linux based systems, this is `~/.config/tanglit` but the exact location can vary by platform.  
It also handles defining the directory to save all temporary files, which in Linux is usually `/tmp/tanglit`

These locations are overrideable by setting the corresponding environment variables:  
* `TANGLIT_TEMP_DIR` for the temporary files directory. `TMPDIR` can also be set to set the directory to `$TMPDIR/tanglit`  
* `TANGLIT_CONFIG_DIR` for the configuration directory

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #69 

