### PR TITLE
Feat: generate default execution configuration

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -62,11 +62,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "directories",
  "env_logger",
+ "include_dir",
  "log",
  "markdown",
  "mdast_util_to_markdown",
@@ -74,8 +82,15 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "temp-env",
  "test-log",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cfg-if"
@@ -130,6 +145,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,10 +189,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -199,6 +261,32 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libredox"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -264,10 +352,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -306,6 +423,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -359,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +563,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -432,6 +590,26 @@ name = "test-log-macros"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -518,6 +696,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "winapi"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,6 +13,10 @@ clap = { version = "4.5.39", features = ["derive", "env"] }
 serde = { version = "1.0.219", features = ["derive"] }
 once_cell = "1.21.3"
 directories = "6.0.0"
+include_dir = {version = "0.7.4", features = ["metadata"] }
+
+[patch.crates-io]
+include_dir = { path = "./libs/include_dir/include_dir" }
 
 [dev-dependencies]
 env_logger = "0.11.8"

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,0 +1,22 @@
+use std::fs::File;
+use std::path::Path;
+use std::time::SystemTime;
+
+fn main() {
+    println!("cargo:rerun-if-changed=resources/config");
+
+    // Touch configuration.rs to force its recompilation
+    let config_file = Path::new("src/configuration/defaults.rs");
+    if config_file.exists() {
+        if let Ok(file) = File::options().write(true).open(config_file) {
+            let now = SystemTime::now();
+            if let Err(e) = file.set_times(
+                std::fs::FileTimes::new()
+                    .set_accessed(now)
+                    .set_modified(now),
+            ) {
+                eprintln!("Warning: Failed to touch configuration.rs: {}", e);
+            }
+        }
+    }
+}

--- a/backend/libs/include_dir/.github/workflows/main.yml
+++ b/backend/libs/include_dir/.github/workflows/main.yml
@@ -1,0 +1,93 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Compile and Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
+          - stable
+          # MSRV
+          - "1.64"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --verbose
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --verbose --no-default-features
+      - name: Test (default features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --verbose
+      - name: Test (glob feature)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --verbose --no-default-features --features glob
+      - name: Test (metadata feature)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --verbose --no-default-features --features metadata
+      - name: Test (nightly feature)
+        uses: actions-rs/cargo@v1
+        if: matrix.rust == 'nightly'
+        with:
+          command: test
+          args: --workspace --verbose --no-default-features --features nightly
+      - name: Test (all features)
+        uses: actions-rs/cargo@v1
+        if: matrix.rust == 'nightly'
+        with:
+          command: test
+          args: --workspace --verbose --all-features
+
+  api-docs:
+    name: Publish API Docs to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --verbose --all-features
+      - name: Redirect top-level GitHub Pages
+        run: "echo '<meta http-equiv=\"refresh\" content=\"0; url=include_dir/index.html\" />' > target/doc/index.html"
+        shell: bash
+      - name: Upload API Docs
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        if: github.ref == 'refs/heads/master'
+        with:
+          branch: gh-pages
+          folder: target/doc

--- a/backend/libs/include_dir/.gitignore
+++ b/backend/libs/include_dir/.gitignore
@@ -1,0 +1,4 @@
+**/*.rs.bk
+/target/
+Cargo.lock
+.vscode

--- a/backend/libs/include_dir/.rust-toolchain.toml
+++ b/backend/libs/include_dir/.rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.64"
+components = [ "rustfmt", "clippy" ]

--- a/backend/libs/include_dir/Cargo.toml
+++ b/backend/libs/include_dir/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+members = ["include_dir", "macros"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.64"
+license = "MIT"
+readme = "README.md"
+version = "0.7.4"
+authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
+repository = "https://github.com/Michael-F-Bryan/include_dir"

--- a/backend/libs/include_dir/LICENSE
+++ b/backend/libs/include_dir/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Michael Bryan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/libs/include_dir/README.md
+++ b/backend/libs/include_dir/README.md
@@ -1,0 +1,53 @@
+# include_dir
+
+[![Continuous Integration](https://github.com/Michael-F-Bryan/include_dir/actions/workflows/main.yml/badge.svg)](https://github.com/Michael-F-Bryan/include_dir/actions/workflows/main.yml)
+[![license](https://img.shields.io/github/license/Michael-F-Bryan/include_dir.svg)](./LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/include_dir.svg)](https://crates.io/crates/include_dir)
+[![Docs.rs](https://docs.rs/include_dir/badge.svg)](https://docs.rs/include_dir/)
+
+An evolution of the `include_str!()` and `include_bytes!()` macros for embedding
+an entire directory tree into your binary.
+
+Rendered Documentation:
+
+- [master](https://michael-f-bryan.github.io/include_dir)
+- [Latest Release](https://docs.rs/include_dir/)
+
+## Getting Started
+
+The `include_dir!()` macro works very similarly to the normal `include_str!()`
+and `include_bytes!()` macros. You pass the macro a file path and assign the
+returned value to some `static` variable.
+
+```rust
+use include_dir::{include_dir, Dir};
+
+static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR");
+
+// of course, you can retrieve a file by its full path
+let lib_rs = PROJECT_DIR.get_file("src/lib.rs").unwrap();
+
+// you can also inspect the file's contents
+let body = lib_rs.contents_utf8().unwrap();
+assert!(body.contains("SOME_INTERESTING_STRING"));
+
+// you can search for files (and directories) using glob patterns
+#[cfg(feature = "glob")]
+{
+    let glob = "**/*.rs";
+    for entry in PROJECT_DIR.find(glob).unwrap() {
+        println!("Found {}", entry.path().display());
+    }
+}
+```
+
+## Features
+
+- Embed a directory tree into your binary at compile time
+- Find a file in the embedded directory
+- Search for files using a glob pattern (requires the `globs` feature)
+- File metadata (requires the `metadata` feature)
+
+To-Do list:
+
+- Compression?

--- a/backend/libs/include_dir/include_dir/Cargo.toml
+++ b/backend/libs/include_dir/include_dir/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "include_dir"
+description = "Embed the contents of a directory in your binary"
+keywords = ["assets", "include", "embed", "dir"]
+categories = ["development-tools", "web-programming", "game-engines"]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+glob = { version = "0.3", optional = true }
+include_dir_macros = { version = "^0.7.4", path = "../macros" }
+
+[dev-dependencies]
+tempfile = "3"
+
+[features]
+default = []
+nightly = ["include_dir_macros/nightly"]
+metadata = ["include_dir_macros/metadata"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/backend/libs/include_dir/include_dir/src/dir.rs
+++ b/backend/libs/include_dir/include_dir/src/dir.rs
@@ -1,0 +1,147 @@
+use crate::{file::File, DirEntry};
+use std::fs;
+use std::path::Path;
+
+/// A directory.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Dir<'a> {
+    path: &'a str,
+    entries: &'a [DirEntry<'a>],
+}
+
+impl<'a> Dir<'a> {
+    /// Create a new [`Dir`].
+    pub const fn new(path: &'a str, entries: &'a [DirEntry<'a>]) -> Self {
+        Dir { path, entries }
+    }
+
+    /// The full path for this [`Dir`], relative to the directory passed to
+    /// [`crate::include_dir!()`].
+    pub fn path(&self) -> &'a Path {
+        Path::new(self.path)
+    }
+
+    /// The entries within this [`Dir`].
+    pub const fn entries(&self) -> &'a [DirEntry<'a>] {
+        self.entries
+    }
+
+    /// Get a list of the files in this directory.
+    pub fn files(&self) -> impl Iterator<Item = &'a File<'a>> + 'a {
+        self.entries().iter().filter_map(DirEntry::as_file)
+    }
+
+    /// Get a list of the sub-directories inside this directory.
+    pub fn dirs(&self) -> impl Iterator<Item = &'a Dir<'a>> + 'a {
+        self.entries().iter().filter_map(DirEntry::as_dir)
+    }
+
+    /// Recursively search for a [`DirEntry`] with a particular path.
+    pub fn get_entry<S: AsRef<Path>>(&self, path: S) -> Option<&'a DirEntry<'a>> {
+        let path = path.as_ref();
+
+        for entry in self.entries() {
+            if entry.path() == path {
+                return Some(entry);
+            }
+
+            if let DirEntry::Dir(d) = entry {
+                if let Some(nested) = d.get_entry(path) {
+                    return Some(nested);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Look up a file by name.
+    pub fn get_file<S: AsRef<Path>>(&self, path: S) -> Option<&'a File<'a>> {
+        self.get_entry(path).and_then(DirEntry::as_file)
+    }
+
+    /// Look up a dir by name.
+    pub fn get_dir<S: AsRef<Path>>(&self, path: S) -> Option<&'a Dir<'a>> {
+        self.get_entry(path).and_then(DirEntry::as_dir)
+    }
+
+    /// Does this directory contain `path`?
+    pub fn contains<S: AsRef<Path>>(&self, path: S) -> bool {
+        self.get_entry(path).is_some()
+    }
+
+    /// Create directories and extract all files to real filesystem.
+    /// Creates parent directories of `path` if they do not already exist.
+    /// Fails if some files already exist.
+    /// In case of error, partially extracted directory may remain on the filesystem.
+    pub fn extract<S: AsRef<Path>>(&self, base_path: S) -> std::io::Result<()> {
+        let base_path = base_path.as_ref();
+
+        for entry in self.entries() {
+            let path = base_path.join(entry.path());
+
+            match entry {
+                DirEntry::Dir(d) => {
+                    fs::create_dir_all(&path)?;
+                    d.extract(base_path)?;
+                }
+                DirEntry::File(f) => {
+                    fs::write(&path, f.contents())?;
+                    set_file_permissions(f, &path)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create directories and extract all files to real filesystem.
+    /// Creates parent directories of `path` if they do not already exist.
+    /// Skips over files that already exist.
+    /// In case of error, partially extracted directory may remain on the filesystem.
+    pub fn extract_soft<S: AsRef<Path>>(&self, base_path: S) -> std::io::Result<()> {
+        let base_path = base_path.as_ref();
+
+        for entry in self.entries() {
+            let path = base_path.join(entry.path());
+
+            match entry {
+                DirEntry::Dir(d) => {
+                    fs::create_dir_all(&path)?;
+                    d.extract_soft(base_path)?;
+                }
+                DirEntry::File(f) => {
+                    if !path.exists() {
+                        fs::write(&path, f.contents())?;
+                        set_file_permissions(f, &path)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(unix, feature = "metadata"))]
+fn set_file_permissions(file: &File<'_>, path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if let Some(metadata) = file.metadata() {
+        if metadata.is_executable() {
+            let mut permissions = fs::metadata(path)?.permissions();
+            let current_mode = permissions.mode();
+            // Add execute bits (owner, group, other) to existing permissions
+            let new_mode = current_mode | 0o111; // 0o111 = execute bits for owner, group, and others
+            permissions.set_mode(new_mode);
+            fs::set_permissions(path, permissions)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(all(unix, feature = "metadata")))]
+fn set_file_permissions(_file: &File, _path: &Path) -> std::io::Result<()> {
+    // No-op on non-Unix platforms or when metadata feature is disabled
+    // In Windows, file execution is given by the extension
+    Ok(())
+}

--- a/backend/libs/include_dir/include_dir/src/dir_entry.rs
+++ b/backend/libs/include_dir/include_dir/src/dir_entry.rs
@@ -1,0 +1,45 @@
+use crate::{Dir, File};
+use std::path::Path;
+
+/// A directory entry, roughly analogous to [`std::fs::DirEntry`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum DirEntry<'a> {
+    /// A directory.
+    Dir(Dir<'a>),
+    /// A file.
+    File(File<'a>),
+}
+
+impl<'a> DirEntry<'a> {
+    /// The [`DirEntry`]'s full path.
+    pub fn path(&self) -> &'a Path {
+        match self {
+            DirEntry::Dir(d) => d.path(),
+            DirEntry::File(f) => f.path(),
+        }
+    }
+
+    /// Try to get this as a [`Dir`], if it is one.
+    pub fn as_dir(&self) -> Option<&Dir<'a>> {
+        match self {
+            DirEntry::Dir(d) => Some(d),
+            DirEntry::File(_) => None,
+        }
+    }
+
+    /// Try to get this as a [`File`], if it is one.
+    pub fn as_file(&self) -> Option<&File<'a>> {
+        match self {
+            DirEntry::File(f) => Some(f),
+            DirEntry::Dir(_) => None,
+        }
+    }
+
+    /// Get this item's sub-items, if it has any.
+    pub fn children(&self) -> &'a [DirEntry<'a>] {
+        match self {
+            DirEntry::Dir(d) => d.entries(),
+            DirEntry::File(_) => &[],
+        }
+    }
+}

--- a/backend/libs/include_dir/include_dir/src/file.rs
+++ b/backend/libs/include_dir/include_dir/src/file.rs
@@ -1,0 +1,81 @@
+use std::{
+    fmt::{self, Debug, Formatter},
+    path::Path,
+};
+
+/// A file with its contents stored in a `&'static [u8]`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct File<'a> {
+    path: &'a str,
+    contents: &'a [u8],
+    #[cfg(feature = "metadata")]
+    metadata: Option<crate::Metadata>,
+}
+
+impl<'a> File<'a> {
+    /// Create a new [`File`].
+    pub const fn new(path: &'a str, contents: &'a [u8]) -> Self {
+        File {
+            path,
+            contents,
+            #[cfg(feature = "metadata")]
+            metadata: None,
+        }
+    }
+
+    /// The full path for this [`File`], relative to the directory passed to
+    /// [`crate::include_dir!()`].
+    pub fn path(&self) -> &'a Path {
+        Path::new(self.path)
+    }
+
+    /// The file's raw contents.
+    pub fn contents(&self) -> &[u8] {
+        self.contents
+    }
+
+    /// The file's contents interpreted as a string.
+    pub fn contents_utf8(&self) -> Option<&str> {
+        std::str::from_utf8(self.contents()).ok()
+    }
+}
+
+#[cfg(feature = "metadata")]
+impl<'a> File<'a> {
+    /// Set the [`Metadata`] associated with a [`File`].
+    pub const fn with_metadata(self, metadata: crate::Metadata) -> Self {
+        let File { path, contents, .. } = self;
+
+        File {
+            path,
+            contents,
+            metadata: Some(metadata),
+        }
+    }
+
+    /// Get the [`File`]'s [`Metadata`], if available.
+    pub fn metadata(&self) -> Option<&crate::Metadata> {
+        self.metadata.as_ref()
+    }
+}
+
+impl<'a> Debug for File<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let File {
+            path,
+            contents,
+            #[cfg(feature = "metadata")]
+            metadata,
+        } = self;
+
+        let mut d = f.debug_struct("File");
+
+        d.field("path", path)
+            .field("contents", &format!("<{} bytes>", contents.len()));
+
+        #[cfg(feature = "metadata")]
+        d.field("metadata", metadata);
+
+        d.finish()
+    }
+}

--- a/backend/libs/include_dir/include_dir/src/globs.rs
+++ b/backend/libs/include_dir/include_dir/src/globs.rs
@@ -1,0 +1,40 @@
+use crate::{Dir, DirEntry};
+use glob::{Pattern, PatternError};
+
+impl<'a> Dir<'a> {
+    /// Search for a file or directory with a glob pattern.
+    pub fn find(&self, glob: &str) -> Result<impl Iterator<Item = &'a DirEntry<'a>>, PatternError> {
+        let pattern = Pattern::new(glob)?;
+
+        Ok(Globs::new(pattern, self))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Globs<'a> {
+    stack: Vec<&'a DirEntry<'a>>,
+    pattern: Pattern,
+}
+
+impl<'a> Globs<'a> {
+    pub(crate) fn new(pattern: Pattern, root: &Dir<'a>) -> Globs<'a> {
+        let stack = root.entries().iter().collect();
+        Globs { stack, pattern }
+    }
+}
+
+impl<'a> Iterator for Globs<'a> {
+    type Item = &'a DirEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(item) = self.stack.pop() {
+            self.stack.extend(item.children());
+
+            if self.pattern.matches_path(item.path()) {
+                return Some(item);
+            }
+        }
+
+        None
+    }
+}

--- a/backend/libs/include_dir/include_dir/src/lib.rs
+++ b/backend/libs/include_dir/include_dir/src/lib.rs
@@ -1,0 +1,111 @@
+//! An extension to the `include_str!()` and `include_bytes!()` macro for
+//! embedding an entire directory tree into your binary.
+//!
+//! # Environment Variables
+//!
+//! When invoking the [`include_dir!()`] macro you should try to avoid using
+//! relative paths because `rustc` makes no guarantees about the current
+//! directory when it is running a procedural macro.
+//!
+//! Environment variable interpolation can be used to remedy this. You might
+//! want to read the [*Environment Variables*][cargo-vars] section of *The
+//! Cargo Book* for a list of variables provided by `cargo`.
+//!
+//! Most crates will want to use the `$CARGO_MANIFEST_DIR` or `$OUT_DIR`
+//! variables. For example, to include a folder relative to your crate you might
+//! use `include_dir!("$CARGO_MANIFEST_DIR/assets")`.
+//!
+//! # Examples
+//!
+//! Here is an example that embeds the `include_dir` crate's source code in a
+//! `static` so we can play around with it.
+//!
+//! ```rust
+//! use include_dir::{include_dir, Dir};
+//! use std::path::Path;
+//!
+//! static PROJECT_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR");
+//!
+//! // of course, you can retrieve a file by its full path
+//! let lib_rs = PROJECT_DIR.get_file("src/lib.rs").unwrap();
+//!
+//! // you can also inspect the file's contents
+//! let body = lib_rs.contents_utf8().unwrap();
+//! assert!(body.contains("SOME_INTERESTING_STRING"));
+//!
+//! // if you enable the `glob` feature, you can for files (and directories) using glob patterns
+//! #[cfg(feature = "glob")]
+//! {
+//!     let glob = "**/*.rs";
+//!     for entry in PROJECT_DIR.find(glob).unwrap() {
+//!         println!("Found {}", entry.path().display());
+//!     }
+//! }
+//! ```
+//!
+//! # Features
+//!
+//! This library exposes a couple feature flags for enabling and disabling extra
+//! functionality. These are:
+//!
+//! - `glob` - search for files using glob patterns
+//! - `metadata` - include some basic filesystem metadata like last modified
+//!   time. This is not enabled by default to allow for more reproducible builds
+//!   and to hide potentially identifying information.
+//! - `nightly` - enables nightly APIs like [`track_path`][track-path]
+//!   and  [`proc_macro_tracked_env`][tracked-env]. This gives the compiler
+//!   more information about what is accessed by the procedural macro, enabling
+//!   better caching. **Functionality behind this feature flag is unstable and
+//!   may change or stop compiling at any time.**
+//!
+//! # Compile Time Considerations
+//!
+//! While the `include_dir!()` macro executes relatively quickly, it expands
+//! to a fairly large amount of code (all your files are essentially embedded
+//! as Rust byte strings) and this may have a flow-on effect on the build
+//! process.
+//!
+//! In particular, including a large number or files or files which are
+//! particularly big may cause the compiler to use large amounts of RAM or spend
+//! a long time parsing your crate.
+//!
+//! As one data point, this crate's `target/` directory contained 620 files with
+//! a total of 64 MB, with a full build taking about 1.5 seconds and 200MB of
+//! RAM to generate a 7MB binary.
+//!
+//! Using `include_dir!("target/")` increased the compile time to 5 seconds
+//! and used 730MB of RAM, generating a 72MB binary.
+//!
+//! [tracked-env]: https://github.com/rust-lang/rust/issues/74690
+//! [track-path]: https://github.com/rust-lang/rust/issues/73921
+//! [cargo-vars]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+
+#![deny(
+    elided_lifetimes_in_paths,
+    future_incompatible,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms
+)]
+#![cfg_attr(feature = "nightly", feature(doc_cfg))]
+
+mod dir;
+mod dir_entry;
+mod file;
+
+#[cfg(feature = "metadata")]
+mod metadata;
+
+#[cfg(feature = "glob")]
+mod globs;
+
+#[cfg(feature = "metadata")]
+pub use crate::metadata::Metadata;
+
+pub use crate::{dir::Dir, dir_entry::DirEntry, file::File};
+pub use include_dir_macros::include_dir;
+
+#[doc = include_str!("../../README.md")]
+#[allow(dead_code)]
+fn check_readme_examples() {}

--- a/backend/libs/include_dir/include_dir/src/metadata.rs
+++ b/backend/libs/include_dir/include_dir/src/metadata.rs
@@ -1,0 +1,55 @@
+use std::time::{Duration, SystemTime};
+
+/// Basic metadata for a file.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Metadata {
+    accessed: Duration,
+    created: Duration,
+    modified: Duration,
+    executable: bool,
+}
+
+impl Metadata {
+    /// Create a new [`Metadata`] using the number of seconds since the
+    /// [`SystemTime::UNIX_EPOCH`].
+    pub const fn new(
+        accessed: Duration,
+        created: Duration,
+        modified: Duration,
+        executable: bool,
+    ) -> Self {
+        Metadata {
+            accessed,
+            created,
+            modified,
+            executable,
+        }
+    }
+
+    /// Get the time this file was last accessed.
+    ///
+    /// See also: [`std::fs::Metadata::accessed()`].
+    pub fn accessed(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + self.accessed
+    }
+
+    /// Get the time this file was created.
+    ///
+    /// See also: [`std::fs::Metadata::created()`].
+    pub fn created(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + self.created
+    }
+
+    /// Get the time this file was last modified.
+    ///
+    /// See also: [`std::fs::Metadata::modified()`].
+    pub fn modified(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + self.modified
+    }
+
+    /// Check if this file is executable.
+    /// See also: [`std::fs::Metadata::permissions()`].
+    pub fn is_executable(&self) -> bool {
+        self.executable
+    }
+}

--- a/backend/libs/include_dir/include_dir/tests/integration_test.rs
+++ b/backend/libs/include_dir/include_dir/tests/integration_test.rs
@@ -1,0 +1,96 @@
+use include_dir::{include_dir, Dir};
+use std::path::Path;
+use tempfile::TempDir;
+
+static PARENT_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR");
+
+#[test]
+fn included_all_files_in_the_include_dir_crate() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    validate_included(&PARENT_DIR, root, root);
+    assert!(PARENT_DIR.contains("src/lib.rs"));
+}
+
+#[test]
+fn extract_all_files() {
+    let tmpdir = TempDir::new().unwrap();
+    let root = tmpdir.path();
+    PARENT_DIR.extract(root).unwrap();
+
+    validate_extracted(&PARENT_DIR, root);
+}
+
+// Validates that all files on the filesystem exist in the inclusion
+fn validate_included(dir: &Dir<'_>, path: &Path, root: &Path) {
+    for entry in path.read_dir().unwrap() {
+        let entry = entry.unwrap().path();
+        let entry = entry.strip_prefix(root).unwrap();
+
+        let name = entry.file_name().unwrap();
+
+        assert!(dir.contains(entry), "Can't find {}", entry.display());
+
+        if entry.is_dir() {
+            let child_path = path.join(name);
+            validate_included(
+                dir.get_entry(entry).unwrap().as_dir().unwrap(),
+                &child_path,
+                root,
+            );
+        }
+    }
+}
+
+// Validates that all files in the inclusion were extracted to the filesystem
+fn validate_extracted(dir: &Dir, path: &Path) {
+    // Check if all the subdirectories exist, recursing on each
+    for subdir in dir.dirs() {
+        let subdir_path = path.join(dir.path());
+        assert!(subdir_path.exists());
+        validate_extracted(subdir, &subdir_path);
+    }
+
+    // Check if the files at the root of this directory exist
+    for file in dir.files() {
+        let file_path = path.join(file.path());
+        assert!(file_path.exists());
+    }
+}
+
+#[test]
+fn msrv_is_in_sync() {
+    let msrv = (include_str!("../../Cargo.toml"))
+        .lines()
+        .filter_map(|line| line.split_once(" = "))
+        .find_map(|(key, value)| {
+            if key.trim() == "rust-version" {
+                Some(value.trim().trim_matches('"'))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let toolchain_version = (include_str!("../../.rust-toolchain.toml"))
+        .lines()
+        .filter_map(|line| line.split_once(" = "))
+        .find_map(|(key, value)| {
+            if key.trim() == "channel" {
+                Some(value.trim().trim_matches('"'))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(toolchain_version, msrv);
+
+    let workflow_msrv = (include_str!("../../.github/workflows/main.yml"))
+        .lines()
+        .skip_while(|line| line.trim() != "# MSRV")
+        .skip(1)
+        .map(|line| line.trim().trim_start_matches('-').trim().trim_matches('"'))
+        .next()
+        .unwrap();
+    assert_eq!(workflow_msrv, msrv);
+}

--- a/backend/libs/include_dir/macros/Cargo.toml
+++ b/backend/libs/include_dir/macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "include_dir_macros"
+description = "The procedural macro used by include_dir"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+
+[features]
+nightly = []
+metadata = []

--- a/backend/libs/include_dir/macros/src/lib.rs
+++ b/backend/libs/include_dir/macros/src/lib.rs
@@ -1,0 +1,369 @@
+//! Implementation details of the `include_dir`.
+//!
+//! You probably don't want to use this crate directly.
+#![cfg_attr(feature = "nightly", feature(track_path, proc_macro_tracked_env))]
+
+use proc_macro::{TokenStream, TokenTree};
+use proc_macro2::Literal;
+use quote::quote;
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+/// Embed the contents of a directory in your crate.
+#[proc_macro]
+pub fn include_dir(input: TokenStream) -> TokenStream {
+    let tokens: Vec<_> = input.into_iter().collect();
+
+    let path = match tokens.as_slice() {
+        [TokenTree::Literal(lit)] => unwrap_string_literal(lit),
+        _ => panic!("This macro only accepts a single, non-empty string argument"),
+    };
+
+    let path = resolve_path(&path, get_env).unwrap();
+
+    expand_dir(&path, &path).into()
+}
+
+fn unwrap_string_literal(lit: &proc_macro::Literal) -> String {
+    let mut repr = lit.to_string();
+    if !repr.starts_with('"') || !repr.ends_with('"') {
+        panic!("This macro only accepts a single, non-empty string argument")
+    }
+
+    repr.remove(0);
+    repr.pop();
+
+    repr
+}
+
+fn expand_dir(root: &Path, path: &Path) -> proc_macro2::TokenStream {
+    let children = read_dir(path).unwrap_or_else(|e| {
+        panic!(
+            "Unable to read the entries in \"{}\": {}",
+            path.display(),
+            e
+        )
+    });
+
+    let mut child_tokens = Vec::new();
+
+    for child in children {
+        if child.is_dir() {
+            let tokens = expand_dir(root, &child);
+            child_tokens.push(quote! {
+                include_dir::DirEntry::Dir(#tokens)
+            });
+        } else if child.is_file() {
+            let tokens = expand_file(root, &child);
+            child_tokens.push(quote! {
+                include_dir::DirEntry::File(#tokens)
+            });
+        } else {
+            panic!("\"{}\" is neither a file nor a directory", child.display());
+        }
+    }
+
+    let path = normalize_path(root, path);
+
+    quote! {
+        include_dir::Dir::new(#path, {
+            const ENTRIES: &'static [include_dir::DirEntry<'static>] = &[ #(#child_tokens),*];
+            ENTRIES
+    })
+    }
+}
+
+fn expand_file(root: &Path, path: &Path) -> proc_macro2::TokenStream {
+    let abs = path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("failed to resolve \"{}\": {}", path.display(), e));
+    let literal = match abs.to_str() {
+        Some(abs) => quote!(include_bytes!(#abs)),
+        None => {
+            let contents = read_file(path);
+            let literal = Literal::byte_string(&contents);
+            quote!(#literal)
+        }
+    };
+
+    let normalized_path = normalize_path(root, path);
+
+    let tokens = quote! {
+        include_dir::File::new(#normalized_path, #literal)
+    };
+
+    match metadata(path) {
+        Some(metadata) => quote!(#tokens.with_metadata(#metadata)),
+        None => tokens,
+    }
+}
+
+fn metadata(path: &Path) -> Option<proc_macro2::TokenStream> {
+    fn to_unix(t: SystemTime) -> u64 {
+        t.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
+    }
+
+    if !cfg!(feature = "metadata") {
+        return None;
+    }
+
+    #[cfg(not(unix))]
+    let is_executable = false;
+
+    let meta = path.metadata().ok()?;
+    let accessed = meta.accessed().map(to_unix).ok()?;
+    let created = meta.created().map(to_unix).ok()?;
+    let modified = meta.modified().map(to_unix).ok()?;
+
+    // Check for executable bit on Unix platforms
+    #[cfg(unix)]
+    let is_executable = {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode();
+        // Check if any execute bit is set (owner, group, or other)
+        (mode & 0o111) != 0
+    };
+
+    Some(quote! {
+        include_dir::Metadata::new(
+            std::time::Duration::from_secs(#accessed),
+            std::time::Duration::from_secs(#created),
+            std::time::Duration::from_secs(#modified),
+            #is_executable,
+        )
+    })
+}
+
+/// Make sure that paths use the same separator regardless of whether the host
+/// machine is Windows or Linux.
+fn normalize_path(root: &Path, path: &Path) -> String {
+    let stripped = path
+        .strip_prefix(root)
+        .expect("Should only ever be called using paths inside the root path");
+    let as_string = stripped.to_string_lossy();
+
+    as_string.replace('\\', "/")
+}
+
+fn read_dir(dir: &Path) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+    if !dir.is_dir() {
+        panic!("\"{}\" is not a directory", dir.display());
+    }
+
+    track_path(dir);
+
+    let mut paths = Vec::new();
+
+    for entry in dir.read_dir()? {
+        let entry = entry?;
+        paths.push(entry.path());
+    }
+
+    paths.sort();
+
+    Ok(paths)
+}
+
+fn read_file(path: &Path) -> Vec<u8> {
+    track_path(path);
+    std::fs::read(path).unwrap_or_else(|e| panic!("Unable to read \"{}\": {}", path.display(), e))
+}
+
+fn resolve_path(
+    raw: &str,
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let mut unprocessed = raw;
+    let mut resolved = String::new();
+
+    while let Some(dollar_sign) = unprocessed.find('$') {
+        let (head, tail) = unprocessed.split_at(dollar_sign);
+        resolved.push_str(head);
+
+        match parse_identifier(&tail[1..]) {
+            Some((variable, rest)) => {
+                let value = get_env(variable).ok_or_else(|| MissingVariable {
+                    variable: variable.to_string(),
+                })?;
+                resolved.push_str(&value);
+                unprocessed = rest;
+            }
+            None => {
+                return Err(UnableToParseVariable { rest: tail.into() }.into());
+            }
+        }
+    }
+    resolved.push_str(unprocessed);
+
+    Ok(PathBuf::from(resolved))
+}
+
+#[derive(Debug, PartialEq)]
+struct MissingVariable {
+    variable: String,
+}
+
+impl Error for MissingVariable {}
+
+impl Display for MissingVariable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Unable to resolve ${}", self.variable)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct UnableToParseVariable {
+    rest: String,
+}
+
+impl Error for UnableToParseVariable {}
+
+impl Display for UnableToParseVariable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Unable to parse a variable from \"{}\"", self.rest)
+    }
+}
+
+fn parse_identifier(text: &str) -> Option<(&str, &str)> {
+    let mut calls = 0;
+
+    let (head, tail) = take_while(text, |c| {
+        calls += 1;
+
+        match c {
+            '_' => true,
+            letter if letter.is_ascii_alphabetic() => true,
+            digit if digit.is_ascii_digit() && calls > 1 => true,
+            _ => false,
+        }
+    });
+
+    if head.is_empty() {
+        None
+    } else {
+        Some((head, tail))
+    }
+}
+
+fn take_while(s: &str, mut predicate: impl FnMut(char) -> bool) -> (&str, &str) {
+    let mut index = 0;
+
+    for c in s.chars() {
+        if predicate(c) {
+            index += c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    s.split_at(index)
+}
+
+#[cfg(feature = "nightly")]
+fn get_env(variable: &str) -> Option<String> {
+    proc_macro::tracked_env::var(variable).ok()
+}
+
+#[cfg(not(feature = "nightly"))]
+fn get_env(variable: &str) -> Option<String> {
+    std::env::var(variable).ok()
+}
+
+fn track_path(_path: &Path) {
+    #[cfg(feature = "nightly")]
+    proc_macro::tracked_path::path(_path.to_string_lossy());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_path_with_no_environment_variables() {
+        let path = "./file.txt";
+
+        let resolved = resolve_path(path, |_| unreachable!()).unwrap();
+
+        assert_eq!(resolved.to_str().unwrap(), path);
+    }
+
+    #[test]
+    fn simple_environment_variable() {
+        let path = "./$VAR";
+
+        let resolved = resolve_path(path, |name| {
+            assert_eq!(name, "VAR");
+            Some("file.txt".to_string())
+        })
+        .unwrap();
+
+        assert_eq!(resolved.to_str().unwrap(), "./file.txt");
+    }
+
+    #[test]
+    fn dont_resolve_recursively() {
+        let path = "./$TOP_LEVEL.txt";
+
+        let resolved = resolve_path(path, |name| match name {
+            "TOP_LEVEL" => Some("$NESTED".to_string()),
+            "$NESTED" => unreachable!("Shouldn't resolve recursively"),
+            _ => unreachable!(),
+        })
+        .unwrap();
+
+        assert_eq!(resolved.to_str().unwrap(), "./$NESTED.txt");
+    }
+
+    #[test]
+    fn parse_valid_identifiers() {
+        let inputs = vec![
+            ("a", "a"),
+            ("a_", "a_"),
+            ("_asf", "_asf"),
+            ("a1", "a1"),
+            ("a1_#sd", "a1_"),
+        ];
+
+        for (src, expected) in inputs {
+            let (got, rest) = parse_identifier(src).unwrap();
+            assert_eq!(got.len() + rest.len(), src.len());
+            assert_eq!(got, expected);
+        }
+    }
+
+    #[test]
+    fn unknown_environment_variable() {
+        let path = "$UNKNOWN";
+
+        let err = resolve_path(path, |_| None).unwrap_err();
+
+        let missing_variable = err.downcast::<MissingVariable>().unwrap();
+        assert_eq!(
+            *missing_variable,
+            MissingVariable {
+                variable: String::from("UNKNOWN"),
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_variables() {
+        let inputs = &["$1", "$"];
+
+        for input in inputs {
+            let err = resolve_path(input, |_| unreachable!()).unwrap_err();
+
+            let err = err.downcast::<UnableToParseVariable>().unwrap();
+            assert_eq!(
+                *err,
+                UnableToParseVariable {
+                    rest: input.to_string(),
+                }
+            );
+        }
+    }
+}

--- a/backend/src/configuration.rs
+++ b/backend/src/configuration.rs
@@ -1,13 +1,16 @@
+mod defaults;
 mod user;
 
 use std::io;
 use user::create_configuration_dirs;
 
+pub use defaults::*;
 pub use user::{get_default_config_dir, get_default_temp_dir};
 
 /// Creates and initializes the default configuration directories.
 pub fn init_configuration() -> io::Result<()> {
     create_configuration_dirs()?;
+    create_default_config(get_default_config_dir())?;
     // any additional initialization logic should go here
     Ok(())
 }

--- a/backend/src/configuration/defaults.rs
+++ b/backend/src/configuration/defaults.rs
@@ -1,0 +1,12 @@
+use std::{io, path::Path};
+
+use include_dir::{Dir, include_dir};
+
+static CONFIG_RESOURCES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/config");
+
+pub fn create_default_config(config_dir_path: &Path) -> io::Result<()> {
+    let config_subdir = &CONFIG_RESOURCES_DIR;
+
+    config_subdir.extract_soft(config_dir_path)?;
+    Ok(())
+}


### PR DESCRIPTION
**Motivation**

Having a way to easily install configuration to the user eases the user experience

**Description**

This PR uses a patched version of the `include_dir` rust crate to handle embedding entire directories into the application binary and extracting it into the user's machine at runtime, without overwriting any existing configuration.

Closes #70 

