### PR TITLE
refactor: rm Language enum

### DIFF
--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -6,7 +6,7 @@ use crate::doc::parser::{ast_to_markdown, parse_code_blocks_from_ast, parse_from
 pub use error::DocError;
 use markdown::mdast::Node;
 pub use parser::ParserError;
-pub use parser::code_block::{CodeBlock, Language};
+pub use parser::code_block::CodeBlock;
 use parser::exclude::exclude_from_ast;
 pub use parser::slides::Slide;
 use parser::slides::parse_slides_from_ast;

--- a/backend/src/doc/parser.rs
+++ b/backend/src/doc/parser.rs
@@ -94,8 +94,6 @@ fn get_code_nodes_from_mdast(mdast: &Node) -> Result<Vec<Code>, ParserError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::doc::parser::code_block::Language;
-
     use super::*;
 
     fn parse_code_blocks_from_string(
@@ -210,7 +208,10 @@ print("Hello, world!")
             blocks.get("block3").unwrap().imports,
             vec!["block1".to_string(), "block2".to_string()]
         );
-        assert_eq!(blocks.get("block3").unwrap().language, Language::Python);
+        assert_eq!(
+            blocks.get("block3").unwrap().language,
+            Option::from("python".to_string())
+        );
     }
 
     #[test]
@@ -225,7 +226,7 @@ print("Hello, world!")
         assert_eq!(block.code.trim(), r#"print("Hello, world!")"#);
         assert_eq!(block.tag, "2".to_string());
         assert!(block.imports.is_empty());
-        assert_eq!(block.language, Language::Python);
+        assert_eq!(block.language, Option::from("python".to_string()));
     }
 
     #[test]

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use super::ParserError;
 use markdown::mdast::Code;
 use regex::Regex;
@@ -7,39 +5,9 @@ use serde::Serialize;
 
 const USE_REGEX: &str = r"use=\[([^\]]*)\]";
 
-#[derive(Debug, PartialEq, Clone, Serialize)]
-pub enum Language {
-    Unknown(String),
-    Python,
-    Rust,
-    C,
-}
-
-impl Language {
-    pub fn parse_language(lang: &str) -> Self {
-        match lang {
-            "python" => Language::Python,
-            "rust" => Language::Rust,
-            "c" => Language::C,
-            other => Language::Unknown(other.to_string()),
-        }
-    }
-}
-
-impl fmt::Display for Language {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Language::Python => write!(f, "Python"),
-            Language::Rust => write!(f, "Rust"),
-            Language::C => write!(f, "C"),
-            Language::Unknown(lang) => write!(f, "{}", lang),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct CodeBlock {
-    pub language: Language,
+    pub language: Option<String>,
     pub code: String,
     pub tag: String,
     pub imports: Vec<String>,
@@ -48,7 +16,7 @@ pub struct CodeBlock {
 
 impl CodeBlock {
     pub fn new(
-        language: Language,
+        language: Option<String>,
         code: String,
         tag: String,
         imports: Vec<String>,
@@ -65,7 +33,7 @@ impl CodeBlock {
 
     pub fn new_with_code(code: String) -> Self {
         Self::new(
-            Language::Unknown("".to_string()),
+            Option::from("".to_string()),
             code,
             "".to_string(),
             Vec::new(),
@@ -76,7 +44,7 @@ impl CodeBlock {
     /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.
     /// If the tag is not specified in the code block, it defaults to the line number of the code block.
     pub fn from_code_node(code_block: Code) -> Result<Self, ParserError> {
-        let language = Language::parse_language(code_block.lang.unwrap_or_default().as_str());
+        let language = code_block.lang;
         let (tag, imports) = Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
         let start_line = code_block
             .position

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -32,13 +32,7 @@ impl CodeBlock {
     }
 
     pub fn new_with_code(code: String) -> Self {
-        Self::new(
-            None,
-            code,
-            "".to_string(),
-            Vec::new(),
-            0,
-        )
+        Self::new(None, code, "".to_string(), Vec::new(), 0)
     }
 
     /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -33,7 +33,7 @@ impl CodeBlock {
 
     pub fn new_with_code(code: String) -> Self {
         Self::new(
-            Option::from("".to_string()),
+            None,
             code,
             "".to_string(),
             Vec::new(),

--- a/backend/src/doc/tangle.rs
+++ b/backend/src/doc/tangle.rs
@@ -85,9 +85,7 @@ impl CodeBlocks {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-    use crate::doc::parser::code_block::Language;
 
     #[test]
     // Tests that imports aren't inserted into the tangled output
@@ -96,7 +94,7 @@ mod tests {
         blocks.insert(
             "main".to_string(),
             CodeBlock::new(
-                Language::Python,
+                Option::from("python".to_string()),
                 "print('Hello, world!')".to_string(),
                 "main".to_string(),
                 vec!["helper".to_string()],
@@ -106,7 +104,7 @@ mod tests {
         blocks.insert(
             "helper".to_string(),
             CodeBlock::new(
-                Language::Python,
+                Option::from("python".to_string()),
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
@@ -129,7 +127,7 @@ mod tests {
         blocks.insert(
             "main".to_string(),
             CodeBlock::new(
-                Language::Python,
+                Option::from("python".to_string()),
                 "print('Hello, world!')".to_string(),
                 "main".to_string(),
                 vec!["helper".to_string()],
@@ -147,7 +145,7 @@ mod tests {
     fn test_resolve_macros() {
         let mut blocks = HashMap::new();
         let main = CodeBlock::new(
-            Language::Python,
+            Option::from("python".to_string()),
             "@[helper]\nprint('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],
@@ -157,7 +155,7 @@ mod tests {
         blocks.insert(
             "helper".to_string(),
             CodeBlock::new(
-                Language::Python,
+                Option::from("python".to_string()),
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
@@ -180,7 +178,7 @@ mod tests {
     fn test_resolve_macros_with_missing_block() {
         let mut blocks = HashMap::new();
         let main = CodeBlock::new(
-            Language::Python,
+            Option::from("python".to_string()),
             "@[helper]\nprint('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],

--- a/backend/src/execution.rs
+++ b/backend/src/execution.rs
@@ -28,7 +28,13 @@ pub fn execute(doc: &TanglitDoc, target_block: &str) -> Result<Output, Execution
     let output = make_executable_code(block, &blocks)?;
 
     // Write the output to a file
-    let block_file_path = write_file(output, target_block, &block.language)
+    let lang = block
+        .language
+        .as_deref()
+        .ok_or(ExecutionError::UnsupportedLanguage(
+            "No language specified".to_string(),
+        ))?;
+    let block_file_path = write_file(output, target_block, lang)
         .map_err(|e| ExecutionError::WriteError(e.to_string()))?;
 
     // Execute the file based on language

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -138,7 +138,7 @@ mod tests {
         println!("Using config path: {}", config_path);
         with_var("TANGLIT_CONFIG_DIR", Some(config_path), || {
             let tangle = make_executable_code(&main, &CodeBlocks::from_codeblocks(blocks)).unwrap();
-            assert_eq ! (
+            assert_eq!(
                 tangle,
                 "#include <stdio.h>\n\n\nint main(){\n    int x;\n    x = 42;\n    printf(\"Hello, world!: %d\",x);\n    return 0;\n}\n"
                 .to_string()

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -139,10 +139,10 @@ mod tests {
         with_var("TANGLIT_CONFIG_DIR", Some(config_path), || {
             let tangle = make_executable_code(&main, &CodeBlocks::from_codeblocks(blocks)).unwrap();
             assert_eq ! (
-    tangle,
-    "#include <stdio.h>\n\n\nint main(){\n    int x;\n    x = 42;\n    printf(\"Hello, world!: %d\",x);\n    return 0;\n}\n"
-    .to_string()
-    );
+                tangle,
+                "#include <stdio.h>\n\n\nint main(){\n    int x;\n    x = 42;\n    printf(\"Hello, world!: %d\",x);\n    return 0;\n}\n"
+                .to_string()
+            );
         });
     }
 }

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -105,7 +105,7 @@ mod tests {
         let mut blocks = HashMap::new();
         let main = CodeBlock::new(
             Option::from("c".to_string()),
-            " @ [x]\nprintf(\"Hello, world!: %d\",x);".to_string(),
+            "@[x]\nprintf(\"Hello, world!: %d\",x);".to_string(),
             "main".to_string(),
             vec!["io".to_string()],
             0,

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -78,8 +78,7 @@ pub fn make_executable_code(
             imports_output.push('\n');
         } else {
             return Err(ExecutionError::InternalError(format!(
-                "Import '{
-}' not found in blocks",
+                "Import '{}' not found in blocks",
                 import
             )));
         }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use backend::cli::{Commands, ExcludeArgs, TangleArgs};
 use backend::configuration::init_configuration;
-use backend::doc::{Language, TangleError, TanglitDoc};
+use backend::doc::{TangleError, TanglitDoc};
 use backend::errors::ExecutionError;
 use backend::errors::ExecutionError::WriteError;
 use backend::{cli::Cli, execution};
@@ -25,7 +25,7 @@ fn handle_tangle_command(tangle_args: TangleArgs) -> Result<String, ExecutionErr
 
     // Write the output to a file
     let output_file_path =
-        get_output_file_path(&tangle_args.output_dir, &tangle_args.target_block, lang);
+        get_output_file_path(&tangle_args.output_dir, &tangle_args.target_block, &lang);
     match write(&output_file_path, output) {
         Ok(_) => Ok(format!("Blocks written to {}", output_file_path.display())),
         Err(e) => Err(WriteError(format!("Error writing to file: {}", e))),
@@ -81,11 +81,15 @@ fn main() {
 }
 
 // TODO: We should get the output file path based on the language
-fn get_output_file_path(output_file_path: &str, main_block: &str, lang: Language) -> PathBuf {
+fn get_output_file_path(
+    output_file_path: &str,
+    main_block: &str,
+    lang: &Option<String>,
+) -> PathBuf {
     let output_file_path = Path::new(output_file_path);
-    match lang {
-        Language::C => output_file_path.join(format!("{main_block}.c")),
-        Language::Python => output_file_path.join(format!("{main_block}.py")),
+    match lang.as_deref().unwrap_or("") {
+        "c" => output_file_path.join(format!("{main_block}.c")),
+        "python" => output_file_path.join(format!("{main_block}.py")),
         _ => output_file_path.join(format!("{main_block}.txt")),
     }
 }


### PR DESCRIPTION
**Motivation**

We have to make the code generic, not hardcoding supported languages.

**Description**

Remove `Language` enum, just use an `Option<String>` instead, as we could have a code block with no language specified. If we try to execute a block with no language specified, an error is raised.

Follow up: https://github.com/TP-FIUBA-133/tanglit/issues/79

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #78

