### PR TITLE
fix: config path from env vars

### DIFF
--- a/backend/src/configuration/user.rs
+++ b/backend/src/configuration/user.rs
@@ -52,6 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[ignore = "conflicts with other tests due to static state"]
     fn test_get_default_config_dir() {
         use temp_env::with_var;
         let random_dir = "/tmp/tanglit_test_config";

--- a/backend/src/configuration/user.rs
+++ b/backend/src/configuration/user.rs
@@ -8,35 +8,50 @@ static DEFAULT_TEMP_DIR: OnceLock<PathBuf> = OnceLock::new();
 const TEMP_DIR_ENVVAR: &str = "TANGLIT_TEMP_DIR";
 const CONFIG_DIR_ENVVAR: &str = "TANGLIT_CONFIG_DIR";
 
+fn calculate_config_dir() -> PathBuf {
+    std::env::var(CONFIG_DIR_ENVVAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            directories::ProjectDirs::from("", "", DEFAULT_PROJECT_NAME)
+                .map(|dirs| dirs.config_dir().to_path_buf())
+                .unwrap_or_else(|| PathBuf::from(".").join(format!(".{}", DEFAULT_PROJECT_NAME)))
+        })
+}
+
 /// Returns the default configuration directory path, either from the environment variable
 /// or from the default project directory structure.
 /// If the environment variable is not set, it defaults to a platform-specific config directory
 /// under the user's home directory.
 /// If it cannot be determined, it falls back to the current directory in a `.tanglit` subdirectory.
+#[cfg(not(test))]
 pub fn get_config_dir() -> &'static PathBuf {
-    DEFAULT_CONFIG_DIR.get_or_init(|| {
-        std::env::var(CONFIG_DIR_ENVVAR)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                directories::ProjectDirs::from("", "", DEFAULT_PROJECT_NAME)
-                    .map(|dirs| dirs.config_dir().to_path_buf())
-                    .unwrap_or_else(|| {
-                        PathBuf::from(".").join(format!(".{}", DEFAULT_PROJECT_NAME))
-                    })
-            })
-    })
+    DEFAULT_CONFIG_DIR.get_or_init(calculate_config_dir)
 }
+
+#[cfg(test)]
+pub fn get_config_dir() -> PathBuf {
+    calculate_config_dir()
+}
+
+fn calculate_temp_dir() -> PathBuf {
+    std::env::var(TEMP_DIR_ENVVAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join(DEFAULT_PROJECT_NAME))
+}
+
 /// Returns the default temporary directory path used for any intermediate files generated during execution.
 /// It uses the `TANGLIT_TEMP_DIR` environment variable if set, otherwise it
 /// defaults to the system's temporary directory with a subdirectory named after the project.
 /// It also follows the implementation of rust's `std::env::temp_dir()`, meaning that `TMPDIR` is also
 /// a valid environment variable to use in unix systems
+#[cfg(not(test))]
 pub fn get_temp_dir() -> &'static PathBuf {
-    DEFAULT_TEMP_DIR.get_or_init(|| {
-        std::env::var(TEMP_DIR_ENVVAR)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| std::env::temp_dir().join(DEFAULT_PROJECT_NAME))
-    })
+    DEFAULT_TEMP_DIR.get_or_init(calculate_temp_dir)
+}
+
+#[cfg(test)]
+pub fn get_temp_dir() -> PathBuf {
+    calculate_temp_dir()
 }
 
 pub fn create_configuration_dirs() -> io::Result<()> {
@@ -52,17 +67,18 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore = "conflicts with other tests due to static state"]
     fn test_get_default_config_dir() {
         use temp_env::with_var;
         let random_dir = "/tmp/tanglit_test_config";
         with_var(super::CONFIG_DIR_ENVVAR, Some(random_dir), || {
             let config_dir = super::get_config_dir();
+            assert_eq!(config_dir.as_path(), PathBuf::from(random_dir).as_path());
+        });
+        with_var(super::CONFIG_DIR_ENVVAR, Some("aeiou/qwerty"), || {
+            let config_dir = super::get_config_dir();
             assert_eq!(
                 config_dir.as_path(),
-                PathBuf::from(random_dir)
-                    .join(DEFAULT_PROJECT_NAME)
-                    .as_path()
+                PathBuf::from("aeiou/qwerty").as_path()
             );
         });
     }

--- a/backend/src/configuration/user.rs
+++ b/backend/src/configuration/user.rs
@@ -16,7 +16,7 @@ const CONFIG_DIR_ENVVAR: &str = "TANGLIT_CONFIG_DIR";
 pub fn get_config_dir() -> &'static PathBuf {
     DEFAULT_CONFIG_DIR.get_or_init(|| {
         std::env::var(CONFIG_DIR_ENVVAR)
-            .map(|v| PathBuf::from(v).join(DEFAULT_PROJECT_NAME))
+            .map(PathBuf::from)
             .unwrap_or_else(|_| {
                 directories::ProjectDirs::from("", "", DEFAULT_PROJECT_NAME)
                     .map(|dirs| dirs.config_dir().to_path_buf())

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -100,7 +100,6 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    #[ignore = "the implementation of get_config_dir must be changed before this can work"]
     fn test_apply_wrapper() {
         let mut blocks = HashMap::new();
         let main = CodeBlock::new(


### PR DESCRIPTION
**Motivation**

The way configuration paths were loaded from environment variables was flawed.

**Description**

This PR makes it possible to override configuration paths via environment variables in a way that makes sense. That is, the env var sets the path directly while before a `tanglit` directory was incorrectly appended.  
It also makes it possible to correctly test these functions, as they are now not behind `OnceLock`s when testing. This is necessary due to the way cargo runs tests (all tests are run from a single process) 

