### PR TITLE
fix generate_pdf temp directory

### DIFF
--- a/backend/src/doc/generate_pdf.rs
+++ b/backend/src/doc/generate_pdf.rs
@@ -1,5 +1,6 @@
-use std::{fmt, fs, path::Path};
+use std::{fmt, fs};
 
+use crate::configuration::get_temp_dir;
 use headless_chrome::{Browser, types::PrintToPdfOptions};
 
 pub enum GeneratePdfError {
@@ -32,9 +33,9 @@ impl From<std::io::Error> for GeneratePdfError {
 }
 
 pub fn generate_pdf(html: &str, output_file_path: &str) -> Result<(), GeneratePdfError> {
-    let temp_file = Path::new("temp.html");
-    fs::write(temp_file, html)?;
-    let abs_path = fs::canonicalize(temp_file)?;
+    let temp_file = get_temp_dir().join("temp.html");
+    fs::write(&temp_file, html)?;
+    let abs_path = fs::canonicalize(&temp_file)?;
     let file_url = format!("file://{}", abs_path.to_string_lossy());
 
     // Launch headless Chromium


### PR DESCRIPTION
**Motivation**

When running with the frontend, the app is reloaded because the temp html is created in the current dir.

**Description**

Use the temp dir to save the temp html file.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes None

