### PR TITLE
refactor: frontend - create tanglit module

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^9.26.0",
         "eslint-plugin-vue": "^10.1.0",
         "globals": "^16.1.0",
-        "prettier": "^3.5.3",
+        "prettier": "^3.6.2",
         "sass-embedded": "^1.89.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.32.0",
@@ -3590,9 +3590,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "eslint": "^9.26.0",
     "eslint-plugin-vue": "^10.1.0",
     "globals": "^16.1.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "sass-embedded": "^1.89.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.32.0",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "clap",
  "comrak",
  "directories",
+ "env_logger",
  "headless_chrome",
  "log",
  "markdown",
@@ -307,6 +308,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1174,6 +1176,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4410,6 +4442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,6 +4663,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
+ "toml_write",
  "winnow 0.7.12",
 ]
 
@@ -4633,6 +4675,12 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow 0.7.12",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -86,8 +86,7 @@ async function run_block(line: number) {
   }
 }
 
-const block_lines = computed(() => all_blocks.value.map(item => item.start_line))
-
+const block_lines = computed(() => all_blocks.value.map((item) => item.start_line));
 </script>
 
 <template>

--- a/frontend/src/MarkdownEditor.vue
+++ b/frontend/src/MarkdownEditor.vue
@@ -9,7 +9,7 @@ type IGlyphMarginWidgetPosition = monaco.editor.IGlyphMarginWidgetPosition;
 
 const raw_markdown_mod = defineModel<string>("raw_markdown");
 const slide_lines_mod = defineModel<number[]>("slide_lines");
-const block_lines_mod = defineModel<number[]>("block_lines");
+const props = defineProps(["block_lines"]);
 
 let margin_glyphs: Record<string, IGlyphMarginWidget> = {};
 const emit = defineEmits(["run-block"]);
@@ -92,7 +92,7 @@ watch(slide_lines_mod, (newValue, oldValue) => {
   });
 });
 
-watch(block_lines_mod, (newValue, oldValue) => {
+watch(() => props.block_lines, (newValue, oldValue) => {
   if (!editor.value) return;
   let editorInstance = editor.value;
 

--- a/frontend/src/MarkdownEditor.vue
+++ b/frontend/src/MarkdownEditor.vue
@@ -92,28 +92,31 @@ watch(slide_lines_mod, (newValue, oldValue) => {
   });
 });
 
-watch(() => props.block_lines, (newValue, oldValue) => {
-  if (!editor.value) return;
-  let editorInstance = editor.value;
+watch(
+  () => props.block_lines,
+  (newValue, oldValue) => {
+    if (!editor.value) return;
+    let editorInstance = editor.value;
 
-  const newLines = new Set(newValue || []);
-  const oldLines = new Set(oldValue || []);
+    const newLines = new Set(newValue || []);
+    const oldLines = new Set(oldValue || []);
 
-  oldValue?.forEach((line) => {
-    if (line < 1) return; // Ensure line numbers are valid
-    if (!newLines.has(line)) {
-      const marginGlyph = margin_glyphs[get_margin_glyph_id(line, "code")];
-      editorInstance.removeGlyphMarginWidget(marginGlyph);
-    }
-  });
-  newValue?.forEach((line) => {
-    if (line < 1) return; // Ensure line numbers are valid
-    if (!oldLines.has(line)) {
-      // Add the margin glyph only if it doesn't already exist
-      add_margin_glyph(RunBlockWidget(line)); // Pass the slide index as extra data
-    }
-  });
-});
+    oldValue?.forEach((line) => {
+      if (line < 1) return; // Ensure line numbers are valid
+      if (!newLines.has(line)) {
+        const marginGlyph = margin_glyphs[get_margin_glyph_id(line, "code")];
+        editorInstance.removeGlyphMarginWidget(marginGlyph);
+      }
+    });
+    newValue?.forEach((line) => {
+      if (line < 1) return; // Ensure line numbers are valid
+      if (!oldLines.has(line)) {
+        // Add the margin glyph only if it doesn't already exist
+        add_margin_glyph(RunBlockWidget(line)); // Pass the slide index as extra data
+      }
+    });
+  },
+);
 </script>
 
 <template>

--- a/frontend/src/tanglit.ts
+++ b/frontend/src/tanglit.ts
@@ -1,0 +1,48 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ExecutionOutput = {
+  stdout: string;
+  stderr: string;
+  status: number;
+};
+
+export type BlockExecute = {
+  error?: unknown;
+  result?: ExecutionOutput;
+};
+
+enum TANGLIT_COMMANDS {
+  exclude = "tanglit_exclude",
+  parse_slides = "tanglit_parse_slides",
+  parse_blocks = "tanglit_parse_blocks",
+  execute = "tanglit_execute_block",
+}
+
+export async function exclude(raw_markdown: string): Promise<string> {
+  return await invoke(TANGLIT_COMMANDS.exclude, { raw_markdown });
+}
+
+export async function parse_slides(raw_markdown: string): Promise<number[]> {
+  let rv = (await invoke(TANGLIT_COMMANDS.parse_slides, { raw_markdown })) as Array<{
+    start_line: number;
+    tag: string;
+  }>;
+  return rv.map((item) => item.start_line);
+}
+
+export async function parse_blocks(raw_markdown: string) {
+  let rv = (await invoke(TANGLIT_COMMANDS.parse_blocks, { raw_markdown })) as Array<{
+    start_line: number;
+    tag: string;
+  }>;
+  return rv;
+}
+
+export async function execute_block(raw_markdown: string, block_name: string): Promise<string> {
+  try {
+    const r = await invoke(TANGLIT_COMMANDS.execute, { raw_markdown, block_name });
+    return { result: r };
+  } catch (e) {
+    return { error: e };
+  }
+}

--- a/frontend/src/tanglit.ts
+++ b/frontend/src/tanglit.ts
@@ -23,7 +23,7 @@ export async function exclude(raw_markdown: string): Promise<string> {
 }
 
 export async function parse_slides(raw_markdown: string): Promise<number[]> {
-  let rv = (await invoke(TANGLIT_COMMANDS.parse_slides, { raw_markdown })) as Array<{
+  const rv = (await invoke(TANGLIT_COMMANDS.parse_slides, { raw_markdown })) as Array<{
     start_line: number;
     tag: string;
   }>;
@@ -31,7 +31,7 @@ export async function parse_slides(raw_markdown: string): Promise<number[]> {
 }
 
 export async function parse_blocks(raw_markdown: string) {
-  let rv = (await invoke(TANGLIT_COMMANDS.parse_blocks, { raw_markdown })) as Array<{
+  const rv = (await invoke(TANGLIT_COMMANDS.parse_blocks, { raw_markdown })) as Array<{
     start_line: number;
     tag: string;
   }>;

--- a/frontend/src/tanglit.ts
+++ b/frontend/src/tanglit.ts
@@ -38,10 +38,10 @@ export async function parse_blocks(raw_markdown: string) {
   return rv;
 }
 
-export async function execute_block(raw_markdown: string, block_name: string): Promise<string> {
+export async function execute_block(raw_markdown: string, block_name: string): Promise<BlockExecute> {
   try {
     const r = await invoke(TANGLIT_COMMANDS.execute, { raw_markdown, block_name });
-    return { result: r };
+    return { result: r as ExecutionOutput };
   } catch (e) {
     return { error: e };
   }


### PR DESCRIPTION
**Motivation**

Make code clearer by having all tanglit functions (those that interact with the rust backend) in a separate module.

**Description**

Move said functions to `tanglit` module. Also fix some typing issues.
Doesn't change any functionality or UI.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes None
