### PR TITLE
refactor: frontend - separate MainMenu component

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,7 @@ import MarkdownEditor from "./MarkdownEditor.vue";
 import { BlockExecute } from "./tanglit.ts";
 import * as tanglit from "./tanglit.ts";
 import BlockExecutionResult from "./BlockExecutionResult.vue";
+import MainMenu from "./MainMenu.vue";
 
 const exclusion_output = ref("");
 const raw_markdown = ref("");
@@ -38,21 +39,10 @@ watch(raw_markdown, async (newValue) => {
   time_to_process.value = Math.floor(end_time - start_time);
 });
 
-const fileInput = ref<HTMLInputElement | null>(null); // Template ref for the hidden input
 const selectedFileName = ref("No file chosen.");
 
-// This function is called when the custom button is clicked
-function triggerFileInput() {
-  if (!fileInput.value) {
-    return;
-  }
-  fileInput.value.click(); // Programmatically clicks the hidden input
-}
-
 // This function is called when a file is selected in the dialog
-function handleFileChange(event: Event) {
-  const input_element = event.target as HTMLInputElement;
-  const file = input_element?.files?.[0]; // Get the first selected file
+function file_selected(file) {
   if (file) {
     selectedFileName.value = file.name;
     // You can now read the file or do whatever you need with it
@@ -68,7 +58,6 @@ function handleFileChange(event: Event) {
       alert("Error reading file: " + e);
     };
     reader.readAsText(file); // Read the file as text
-    input_element.value = ""; // Reset the input to allow re-selection of the same file
   } else {
     selectedFileName.value = "No file chosen.";
   }
@@ -107,20 +96,7 @@ const block_lines = computed(() => all_blocks.value.map((item) => item.start_lin
         <BlockExecutionResult :result="block_execute" />
       </div>
     </div>
-    <div class="status-bar">
-      <div class="buttons">
-        <div>
-          <button @click="triggerFileInput" class="custom-file-upload">Open</button>
-          <input type="file" ref="fileInput" @change="handleFileChange" style="display: none" accept=".md,.txt" />
-        </div>
-        <button title="Save">Save</button>
-        <button title="Load sample markdown" @click="load_sample_markdown">Sample markdown</button>
-        <button title="Export slides">Export slides</button>
-        <button title="Export to doc">Export doc</button>
-        <button title="Tangle code">Tangle code</button>
-      </div>
-      <div>Time to process: {{ time_to_process }} ms</div>
-    </div>
+    <MainMenu v-on:load_sample_markdown="load_sample_markdown" v-on:file_selected="file_selected" />
   </main>
 </template>
 
@@ -158,7 +134,6 @@ body {
   flex-direction: column;
   justify-content: center;
   text-align: center;
-  background-color: #00931f;
   height: 100vh;
 }
 
@@ -201,17 +176,6 @@ body {
   align-items: center;
 }
 
-.buttons {
-  display: flex;
-  flex-direction: row;
-  gap: 5px;
-}
-
-.buttons button {
-  background-color: #003974;
-  border-radius: 0;
-}
-
 .logo {
   height: 6em;
   padding: 1.5em;
@@ -226,72 +190,5 @@ body {
 .row {
   display: flex;
   justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
-  outline: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
-  }
-
-  a:hover {
-    color: #24c8db;
-  }
-
-  input,
-  button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
-  }
-
-  button:active {
-    background-color: #0f0f0f69;
-  }
 }
 </style>

--- a/frontend/src/MainMenu.vue
+++ b/frontend/src/MainMenu.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const emit = defineEmits(["load_sample_markdown", "file_selected"]);
+const fileInput = ref<HTMLInputElement | null>(null); // Template ref for the hidden input
+
+function triggerFileInput() {
+  if (!fileInput.value) {
+    return;
+  }
+  fileInput.value.click(); // Programmatically clicks the hidden input
+}
+
+function handleFileChange(event: Event) {
+  const input_element = event.target as HTMLInputElement;
+  const file = input_element?.files?.[0]; // Get the first selected file
+  emit("file_selected", file);
+  input_element.value = ""; // Reset the input to allow re-selection of the same file
+}
+</script>
+
+<template>
+  <input type="file" ref="fileInput" @change="handleFileChange" style="display: none" accept=".md,.txt" />
+  <div>
+    <button @click="triggerFileInput" class="custom-file-upload">Open</button>
+    <button title="Save">Save</button>
+    <button title="Load sample markdown" @click="$emit('load_sample_markdown')">Sample markdown</button>
+    <button title="Export slides">Export slides</button>
+    <button title="Export to doc">Export doc</button>
+    <button title="Tangle code">Tangle code</button>
+  </div>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
**Motivation**

Clean up the main App.vue file. Make the code clearer and easier to maintain.

**Description**

Create MainMenu component. This component should emit events to the parent, and the parent should handle them appropriately. Right now we only have file_selected, and load_sample_markdown; but we should do the same for export, tangle, etc. So maybe in the future we could have keyboard shortcuts etc. that emit those same events. And they are handled in only one place (the parent App).

Also I removed some of the css classes that were not really good. We'll try to make everything look better in future PRs.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #99 

