### PR TITLE
feat: frontend slide view

### DIFF
--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -72,6 +72,17 @@ impl TanglitDoc {
         Ok(())
     }
 
+    pub fn generate_md_slides_vec(&self) -> Result<Vec<String>, DocError> {
+        let slides = parse_slides_from_ast(&self.ast, &self.raw_markdown);
+        let mut v: Vec<String> = vec![];
+        for slide in slides.iter() {
+            let slide_md = slide.to_markdown()?;
+            v.push(slide_md);
+        }
+
+        Ok(v)
+    }
+
     pub fn exclude(&self) -> Result<String, DocError> {
         let ast_with_exclusions = exclude_from_ast(&self.ast);
         Ok(ast_to_markdown(&ast_with_exclusions)?)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,14 @@
         "@guolao/vue-monaco-editor": "^1.5.5",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "hash-sum": "^2.0.0",
         "splitpanes": "^4.0.4",
         "vue": "^3.5.13"
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@tauri-apps/cli": "^2",
+        "@types/hash-sum": "^1.0.2",
         "@types/splitpanes": "^2.2.6",
         "@vitejs/plugin-vue": "^5.2.1",
         "eslint": "^9.26.0",
@@ -1416,6 +1418,12 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hash-sum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha512-UP28RddqY8xcU0SCEp9YKutQICXpaAq9N8U2klqF5hegGha7KzTOL8EdhIIV3bOSGBzjEpN9bU/d+nNZBdJYVw==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2966,6 +2974,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,12 +14,14 @@
     "@guolao/vue-monaco-editor": "^1.5.5",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "hash-sum": "^2.0.0",
     "splitpanes": "^4.0.4",
     "vue": "^3.5.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@tauri-apps/cli": "^2",
+    "@types/hash-sum": "^1.0.2",
     "@types/splitpanes": "^2.2.6",
     "@vitejs/plugin-vue": "^5.2.1",
     "eslint": "^9.26.0",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -51,6 +51,16 @@ fn tanglit_execute_block(raw_markdown: &str, block_name: &str) -> Result<Executi
     }
 }
 
+#[tauri::command(rename_all = "snake_case")]
+fn tanglit_gen_slides(raw_markdown: &str) -> Result<Vec<String>, String> {
+    let doc = TanglitDoc::new_from_string(raw_markdown)
+        .map_err(|e| format!("Error creating TanglitDoc: {}", e))?;
+    let slides = doc
+        .generate_md_slides_vec()
+        .map_err(|e| format!("Error generating Md slides: {}", e))?;
+    Ok(slides)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -59,7 +69,8 @@ pub fn run() {
             tanglit_exclude,
             tanglit_parse_slides,
             tanglit_parse_blocks,
-            tanglit_execute_block
+            tanglit_execute_block,
+            tanglit_gen_slides
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,10 +7,12 @@ import BlockExecutionResult from "./BlockExecutionResult.vue";
 import MainMenu from "./MainMenu.vue";
 import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
+import SlideViewMain from "./SlideViewMain.vue";
 
 const exclusion_output = ref("");
 const raw_markdown = ref("");
 const slides = ref<number[]>([]);
+const slides_markdown = ref<string[]>([]);
 const all_blocks = ref<{ start_line: number; tag: string }[]>([]);
 const block_execute = ref<BlockExecute>({ error: undefined, result: undefined });
 
@@ -78,6 +80,11 @@ async function run_block(line: number) {
   }
 }
 
+async function preview_slides() {
+  slides_markdown.value = await tanglit.gen_slides(raw_markdown.value);
+  console.log("Slides generated:", slides_markdown.value);
+}
+
 const block_lines = computed(() => all_blocks.value.map((item) => item.start_line));
 </script>
 
@@ -97,7 +104,7 @@ const block_lines = computed(() => all_blocks.value.map((item) => item.start_lin
         <pane min-size="30">
           <splitpanes horizontal class="default-theme">
             <pane min-size="30">
-              <div class="exclusion_output">{{ exclusion_output }}</div>
+              <SlideViewMain class="slide-view" :slides_markdown="slides_markdown" />
             </pane>
             <pane min-size="30">
               <BlockExecutionResult :result="block_execute" />
@@ -106,7 +113,11 @@ const block_lines = computed(() => all_blocks.value.map((item) => item.start_lin
         </pane>
       </splitpanes>
     </div>
-    <MainMenu v-on:load_sample_markdown="load_sample_markdown" v-on:file_selected="file_selected" />
+    <MainMenu
+      v-on:load_sample_markdown="load_sample_markdown"
+      v-on:file_selected="file_selected"
+      v-on:preview_slides="preview_slides"
+    />
   </main>
 </template>
 
@@ -123,6 +134,11 @@ const block_lines = computed(() => all_blocks.value.map((item) => item.start_lin
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+.slide-view {
+  height: 100%;
+  width: 600px;
 }
 
 html,

--- a/frontend/src/MainMenu.vue
+++ b/frontend/src/MainMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-const emit = defineEmits(["load_sample_markdown", "file_selected"]);
+const emit = defineEmits(["load_sample_markdown", "file_selected", "preview_slides"]);
 const fileInput = ref<HTMLInputElement | null>(null); // Template ref for the hidden input
 
 function triggerFileInput() {
@@ -25,7 +25,7 @@ function handleFileChange(event: Event) {
     <button @click="triggerFileInput" class="custom-file-upload">Open</button>
     <button title="Save">Save</button>
     <button title="Load sample markdown" @click="$emit('load_sample_markdown')">Sample markdown</button>
-    <button title="Export slides">Export slides</button>
+    <button title="Preview slides" @click="$emit('preview_slides')">Preview slides</button>
     <button title="Export to doc">Export doc</button>
     <button title="Tangle code">Tangle code</button>
   </div>

--- a/frontend/src/SlideView.vue
+++ b/frontend/src/SlideView.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import Reveal from "reveal.js";
+import "reveal.js/dist/reveal.css";
+import "reveal.js/dist/theme/black.css"; // you can pick another theme
+import Markdown from "reveal.js/plugin/markdown/markdown.esm.js";
+import Highlight from "reveal.js/plugin/highlight/highlight.esm.js";
+import "reveal.js/plugin/highlight/monokai.css";
+
+const { slides_markdown } = defineProps<{ slides_markdown: string[] }>();
+
+let deck: Reveal.Api | null = null;
+
+function initReveal() {
+  // Reveal.initialize({
+  //   plugins: [ RevealMarkdown,  ],
+  //
+  // });
+
+  deck = new Reveal({
+    plugins: [Markdown, Highlight],
+    embedded: true,
+    hash: true,
+  });
+
+  deck.on("ready", () => {
+    document.querySelectorAll(".reveal section h1, .reveal section h2").forEach((el) => el.classList.add("r-fit-text"));
+  });
+
+  // Also maybe on slidechanged event:
+  deck.on("slidechanged", (event) => {
+    event.currentSlide.querySelectorAll("h1, h2").forEach((el) => el.classList.add("r-fit-text"));
+  });
+
+  deck.initialize();
+}
+
+onMounted(() => {
+  initReveal();
+});
+</script>
+
+<template>
+  <div class="reveal">
+    <div class="slides">
+      <section v-for="(md, index) in slides_markdown" :key="index" data-markdown>
+        <div data-template v-html="md"></div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.reveal {
+  font-family: sans-serif !important;
+  height: 100%;
+  width: 100%;
+}
+</style>

--- a/frontend/src/SlideViewMain.vue
+++ b/frontend/src/SlideViewMain.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import SlideView from "./SlideView.vue";
+import sum from "hash-sum";
+
+const { slides_markdown } = defineProps<{ slides_markdown: string[] }>();
+
+function make_key(slides_markdown: string[]): string {
+  let start = performance.now();
+  let y = sum(slides_markdown);
+  let end = performance.now();
+  console.log("hash took: ", end - start);
+  return y;
+}
+</script>
+
+<!--We use this wrapper over SlideView to hide the :key part which is not very intuitive, -->
+<!--but it's the way to force a re-render of SlideView when slides_markdown changes.-->
+
+<template>
+  <SlideView :slides_markdown="slides_markdown" :key="make_key(slides_markdown)" />
+</template>
+
+<style scoped></style>

--- a/frontend/src/tanglit.ts
+++ b/frontend/src/tanglit.ts
@@ -16,6 +16,7 @@ enum TANGLIT_COMMANDS {
   parse_slides = "tanglit_parse_slides",
   parse_blocks = "tanglit_parse_blocks",
   execute = "tanglit_execute_block",
+  gen_slides = "tanglit_gen_slides",
 }
 
 export async function exclude(raw_markdown: string): Promise<string> {
@@ -44,5 +45,14 @@ export async function execute_block(raw_markdown: string, block_name: string): P
     return { output: r as ExecutionOutput };
   } catch (e) {
     return { error: e };
+  }
+}
+
+export async function gen_slides(raw_markdown: string): Promise<string[]> {
+  try {
+    const r = (await invoke(TANGLIT_COMMANDS.gen_slides, { raw_markdown })) as string[];
+    return r;
+  } catch {
+    return [];
   }
 }


### PR DESCRIPTION
**Motivation**

Preview slides in frontend.

**Description**

Add SlideViewMain component that uses reveal.js to show the markdown slides. Press Preview slides to update the slides. Go back/forward with arrows. Press F for fullscreen. 
In `doc.rs` (backend) I add a function to generate the markdown and return it as a vector of strings instead of writing to a file, since it's more direct.


https://github.com/user-attachments/assets/4f989bee-a862-4097-b0ff-7749b08ee11f



<!-- Link to issues: Closes #111, Closes #222 -->

Closes #110 

