### PR TITLE
feat: insert output in markdown after code block (WIP)

### DIFF
--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -8,6 +8,7 @@ use crate::doc::parser::slides::parse_slides_from_ast;
 use crate::doc::parser::{
     ast_to_markdown, markdown_to_html, parse_code_blocks_from_ast, parse_from_string,
 };
+use crate::execution::ExecutionOutput;
 pub use error::DocError;
 use markdown::mdast::Node;
 pub use parser::ParserError;
@@ -15,6 +16,7 @@ pub use parser::code_block::CodeBlock;
 use parser::exclude::exclude_from_ast;
 pub use parser::slides::SlideByIndex;
 use parser::slides::parse_slides_index_from_ast;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
 pub use tangle::CodeBlocks;
@@ -23,6 +25,12 @@ pub use tangle::TangleError;
 pub struct TanglitDoc {
     raw_markdown: String,
     ast: Node,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Edit {
+    pub content: String,
+    pub line: usize,
 }
 
 impl TanglitDoc {
@@ -70,6 +78,27 @@ impl TanglitDoc {
         }
 
         Ok(())
+    }
+
+    pub fn format_output(
+        &self,
+        block_id: &str,
+        output: &ExecutionOutput,
+    ) -> Result<Edit, DocError> {
+        Ok(Edit {
+            content: format!(
+                "```output\nOutput:\n{}\n\nStderr:\n{}\n\nExit code: {}\n```",
+                output.stdout,
+                output.stderr,
+                output.status.map_or("None".to_string(), |s| s.to_string())
+            ),
+            line: self
+                .get_code_blocks()?
+                .get_block(block_id)
+                .unwrap()
+                .end_line
+                + 1,
+        })
     }
 
     pub fn exclude(&self) -> Result<String, DocError> {

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -12,6 +12,7 @@ pub struct CodeBlock {
     pub tag: String,
     pub imports: Vec<String>,
     pub start_line: usize,
+    pub end_line: usize,
 }
 
 impl CodeBlock {
@@ -21,6 +22,7 @@ impl CodeBlock {
         tag: String,
         imports: Vec<String>,
         start_line: usize,
+        end_line: usize,
     ) -> Self {
         Self {
             language,
@@ -28,11 +30,12 @@ impl CodeBlock {
             tag,
             imports,
             start_line,
+            end_line,
         }
     }
 
     pub fn new_with_code(code: String) -> Self {
-        Self::new(None, code, "".to_string(), Vec::new(), 0)
+        Self::new(None, code, "".to_string(), Vec::new(), 0, 0)
     }
 
     /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.
@@ -40,10 +43,14 @@ impl CodeBlock {
     pub fn from_code_node(code_block: Code) -> Result<Self, ParserError> {
         let language = code_block.lang;
         let (tag, imports) = Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
-        let start_line = code_block
-            .position
+        let position = code_block.position.as_ref();
+        let start_line = position
             .ok_or_else(|| ParserError::CodeBlockError("Block position not found".to_string()))?
             .start
+            .line;
+        let end_line = position
+            .ok_or_else(|| ParserError::CodeBlockError("Block position not found".to_string()))?
+            .end
             .line;
         let tag = match tag {
             Some(t) => t,
@@ -56,6 +63,7 @@ impl CodeBlock {
             tag,
             imports,
             start_line,
+            end_line,
         ))
     }
 

--- a/backend/src/doc/tangle.rs
+++ b/backend/src/doc/tangle.rs
@@ -106,6 +106,7 @@ mod tests {
                 "main".to_string(),
                 vec!["helper".to_string()],
                 0,
+                0,
             ),
         );
         blocks.insert(
@@ -115,6 +116,7 @@ mod tests {
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                0,
                 0,
             ),
         );
@@ -139,6 +141,7 @@ mod tests {
                 "main".to_string(),
                 vec!["helper".to_string()],
                 0,
+                0,
             ),
         );
         let codeblocks = CodeBlocks::from_codeblocks(blocks);
@@ -157,6 +160,7 @@ mod tests {
             "main".to_string(),
             vec![],
             0,
+            0,
         );
         blocks.insert("main".to_string(), main.clone());
         blocks.insert(
@@ -166,6 +170,7 @@ mod tests {
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                0,
                 0,
             ),
         );
@@ -189,6 +194,7 @@ mod tests {
             "@[helper]\nprint('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],
+            0,
             0,
         );
         blocks.insert("main".to_string(), main.clone());
@@ -214,6 +220,7 @@ mod tests {
             "main".to_string(),
             vec![],
             0,
+            0,
         );
         blocks.insert("main".to_string(), main.clone());
         blocks.insert(
@@ -223,6 +230,7 @@ mod tests {
                 "print('Helper function')\nprint('second helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                0,
                 0,
             ),
         );

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -121,6 +121,7 @@ mod tests {
             "main".to_string(),
             vec!["io".to_string()],
             0,
+            0,
         );
         blocks.insert("main".to_string(), main.clone());
         blocks.insert(
@@ -131,6 +132,7 @@ mod tests {
                 "io".to_string(),
                 vec![],
                 0,
+                0,
             ),
         );
         blocks.insert(
@@ -140,6 +142,7 @@ mod tests {
                 "int x;\nx = 42;".to_string(),
                 "x".to_string(),
                 vec![],
+                0,
                 0,
             ),
         );

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -66,9 +66,9 @@ fn handle_execute_command(
     Ok(format!(
         "Output of block {}:\n{}\nstderr: {}\nexit code: {}",
         execute_args.target_block,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-        &output.status
+        output.stdout,
+        output.stderr,
+        output.status.unwrap_or(-1)
     ))
 }
 

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use backend::configuration::init_configuration;
-use backend::doc::{CodeBlock, SlideByIndex, TanglitDoc};
-use serde::Serialize;
+use backend::doc::{CodeBlock, Edit, SlideByIndex, TanglitDoc};
+use backend::execution::ExecutionOutput;
 
 #[tauri::command(rename_all = "snake_case")]
 fn tanglit_exclude(raw_markdown: &str) -> Result<String, String> {
@@ -28,27 +28,27 @@ fn tanglit_parse_blocks(raw_markdown: &str) -> Result<Vec<CodeBlock>, String> {
     Ok(blocks)
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct ExecutionOutput {
-    pub status: Option<i32>,
-    pub stdout: String,
-    pub stderr: String,
-}
-
 #[tauri::command(rename_all = "snake_case")]
 fn tanglit_execute_block(raw_markdown: &str, block_name: &str) -> Result<ExecutionOutput, String> {
     init_configuration().map_err(|e| format!("Error initializing configuration: {}", e))?;
     let doc = TanglitDoc::new_from_string(raw_markdown)
         .map_err(|e| format!("Error creating TanglitDoc: {}", e))?;
 
-    match backend::execution::execute(&doc, block_name) {
-        Ok(output) => Ok(ExecutionOutput {
-            status: output.status.code(),
-            stdout: String::from_utf8(output.stdout).expect("Error reading stdout"),
-            stderr: String::from_utf8(output.stderr).expect("Error reading stderr"),
-        }),
-        Err(e) => Err(format!("Error executing block: {}", e)),
-    }
+    backend::execution::execute(&doc, block_name)
+        .map_err(|e| format!("Error executing block: {}", e))
+}
+
+#[tauri::command(rename_all = "snake_case")]
+fn tanglit_format_output(
+    raw_markdown: &str,
+    block_name: &str,
+    output: ExecutionOutput,
+) -> Result<Edit, String> {
+    init_configuration().map_err(|e| format!("Error initializing configuration: {}", e))?;
+    let doc = TanglitDoc::new_from_string(raw_markdown)
+        .map_err(|e| format!("Error creating TanglitDoc: {}", e))?;
+    doc.format_output(block_name, &output)
+        .map_err(|e| format!("Error formatting output: {}", e))
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -59,7 +59,8 @@ pub fn run() {
             tanglit_exclude,
             tanglit_parse_slides,
             tanglit_parse_blocks,
-            tanglit_execute_block
+            tanglit_execute_block,
+            tanglit_format_output
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/frontend/src/BlockExecutionResult.vue
+++ b/frontend/src/BlockExecutionResult.vue
@@ -1,36 +1,64 @@
 <script setup lang="ts">
-import { BlockExecute } from "./tanglit.ts";
-
-const { result } = defineProps<{ result: BlockExecute }>();
+const props = defineProps(["result", "line"]);
+console.log("Initial result:", props.result);
+defineEmits(["add_output_to_markdown", "run_block", "close"]);
 </script>
 <template>
   <div class="result">
-    Block execution
-    <div class="error" v-if="result.error"><span>Error</span>{{ result.error }}</div>
-    <div v-else-if="result.output">
+    <button class="close" @click="$emit('close')">Close</button>
+    <div class="top">
+      <span>Block execution</span>
+      <button @click="$emit('run_block', line)">Run</button>
+    </div>
+    <div class="error" v-if="props.result.error"><span>Error</span>{{ result.error }}</div>
+    <div class="output-main" v-else-if="result.output">
       <div class="output">
         <div class="output-title">status</div>
-        <div class="output-content">{{ result.output.status }}</div>
+        <div class="output-content">{{ props.result.output.status }}</div>
       </div>
       <div class="output">
         <div class="output-title">stdout</div>
-        <div class="output-content">{{ result.output.stdout }}</div>
+        <div class="output-content">{{ props.result.output.stdout }}</div>
       </div>
-      <div class="output">
+      <div class="output" v-if="props.result.output.stderr">
         <div class="output-title">stderr</div>
-        <div class="output-content">{{ result.output.stderr }}</div>
+        <div class="output-content">{{ props.result.output.stderr }}</div>
       </div>
+      <button @click="$emit('add_output_to_markdown', props.result.output)">Add to markdown</button>
     </div>
   </div>
 </template>
 
 <style scoped>
+.top {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5pt;
+  gap: 10pt;
+}
+.close {
+  position: absolute;
+  top: 5pt;
+  right: 5pt;
+  background-color: #4a4a4a;
+  color: white;
+  border: none;
+  border-radius: 3pt;
+  padding: 2pt 5pt;
+}
+
 .result {
   display: flex;
   flex-direction: column;
-  background-color: #006eb3;
-  color: white;
-  gap: 5px;
+  background-color: #454545;
+  color: #d3d3d3;
+  padding: 5pt;
+}
+
+.output-main {
+  gap: 5pt;
+  display: flex;
+  flex-direction: column;
 }
 
 .error {
@@ -43,7 +71,7 @@ const { result } = defineProps<{ result: BlockExecute }>();
 }
 
 .output {
-  background-color: #00304e;
+  background-color: #333333;
   margin: 2px;
 }
 

--- a/frontend/src/MarkdownEditor.vue
+++ b/frontend/src/MarkdownEditor.vue
@@ -1,18 +1,21 @@
 <script lang="ts" setup>
-import { shallowRef, watch } from "vue";
+import { createApp, h, ref, shallowRef, watch } from "vue";
 import VueMonacoEditor from "@guolao/vue-monaco-editor";
 import * as monaco from "monaco-editor";
+import BlockExecutionResult from "./BlockExecutionResult.vue";
+import { BlockExecute } from "./tanglit.ts";
 
 type ICodeEditor = monaco.editor.ICodeEditor;
 type IGlyphMarginWidget = monaco.editor.IGlyphMarginWidget;
 type IGlyphMarginWidgetPosition = monaco.editor.IGlyphMarginWidgetPosition;
+type IContentWidgetPosition = monaco.editor.IContentWidgetPosition;
 
 const raw_markdown_mod = defineModel<string>("raw_markdown");
 const slide_lines_mod = defineModel<number[]>("slide_lines");
-const props = defineProps(["block_lines"]);
+const props = defineProps(["block_lines", "block_execute"]);
 
 let margin_glyphs: Record<string, IGlyphMarginWidget> = {};
-const emit = defineEmits(["run-block"]);
+const emit = defineEmits(["run-block", "add_output_to_markdown"]);
 const MONACO_EDITOR_OPTIONS = {
   automaticLayout: true,
   formatOnType: true,
@@ -20,8 +23,78 @@ const MONACO_EDITOR_OPTIONS = {
   glyphMargin: true,
 };
 
+const my_widget = ref();
+
 const editor = shallowRef<ICodeEditor>();
 const handleMount = (editorInstance: ICodeEditor) => (editor.value = editorInstance);
+watch(
+  () => props.block_execute,
+  (new_value, old_value) => {
+    console.log("new block_execute: ", new_value);
+    console.log("old block_execute: ", old_value);
+    makeBlockResult(new_value.line, new_value);
+  },
+);
+
+function close_widget() {
+  if (!editor.value) return;
+  console.log("close_widget: ", my_widget.value);
+  editor.value.removeContentWidget(my_widget.value.widget);
+  my_widget.value.unmount();
+  my_widget.value = "";
+}
+
+function makeBlockResult(line_number: number, result: BlockExecute) {
+  if (my_widget.value) {
+    close_widget();
+  }
+  let widget_dom = document.createElement("div");
+  const app = createApp(
+    h(BlockExecutionResult, {
+      result: result,
+      line: line_number,
+      onRun_block: () => emit("run-block", line_number),
+      onClose: close_widget,
+      onAdd_output_to_markdown: () => emit("add_output_to_markdown", line_number, result.output),
+    }),
+  );
+
+  app.mount(widget_dom);
+  widget_dom.className = "block-result-widget";
+  let random_suffix = Math.floor(Math.random() * 1000000);
+  let widget_id = "block_result_widget" + random_suffix;
+  let w = {
+    getId: function () {
+      return widget_id;
+    },
+    getDomNode: function () {
+      return widget_dom;
+    },
+    getPosition: function (): IContentWidgetPosition {
+      return {
+        position: { lineNumber: line_number, column: 1 },
+        // Place it below the current line
+        preference: [monaco.editor.ContentWidgetPositionPreference.BELOW],
+      };
+    },
+  };
+  my_widget.value = { widget: w, unmount: app.unmount, line: line_number };
+  editor.value?.addContentWidget(w);
+}
+
+function add_output_to_markdown(text: string, line_number: number) {
+  console.log("text: ", text);
+  console.log("line_number: ", line_number);
+  editor.value?.executeEdits("embed-result", [
+    {
+      range: new monaco.Range(line_number, 1, line_number, 1),
+      text: text + "\n", // Add the text on the next line
+      forceMoveMarkers: true,
+    },
+  ]);
+}
+
+defineExpose({ makeBlockResult: makeBlockResult, add_output_to_markdown: add_output_to_markdown });
 
 function makeGlyphWidget(line: number, widget_id: string, widget_dom: HTMLElement): IGlyphMarginWidget {
   return {
@@ -54,7 +127,8 @@ function RunBlockWidget(line: number): IGlyphMarginWidget {
   widgetNode.className = "run-block-widget";
   widgetNode.onclick = () => {
     // emit an event to run the block
-    emit("run-block", line);
+    // emit("run-block", line);
+    makeBlockResult(line, { line: line, output: null, error: null });
   };
   return makeGlyphWidget(line, get_margin_glyph_id(line, "code"), widgetNode);
 }
@@ -141,6 +215,16 @@ watch(
 
 .run-block-widget {
   padding: 0;
+}
+
+.block-result-widget {
+  background-color: #272727;
+  border: 1px solid #5e5e5e;
+  padding: 8px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  min-width: 20em;
+  z-index: 10000;
 }
 
 .run-block-widget button {

--- a/frontend/src/assets/example.md
+++ b/frontend/src/assets/example.md
@@ -10,7 +10,13 @@ This slide has the same title as the first slide.
 This slide has a code block:
 
 ```python
-print("Hello, world!")
+import random
+print("One random number:", random.randint(1, 2**32))
+```
+
+```python
+import random
+print("Another random number:", random.randint(1, 2**32))
 ```
 
 --- ---

--- a/frontend/src/tanglit.ts
+++ b/frontend/src/tanglit.ts
@@ -16,6 +16,7 @@ enum TANGLIT_COMMANDS {
   parse_slides = "tanglit_parse_slides",
   parse_blocks = "tanglit_parse_blocks",
   execute = "tanglit_execute_block",
+  format_output = "tanglit_format_output",
 }
 
 export async function exclude(raw_markdown: string): Promise<string> {
@@ -42,6 +43,16 @@ export async function execute_block(raw_markdown: string, block_name: string): P
   try {
     const r = await invoke(TANGLIT_COMMANDS.execute, { raw_markdown, block_name });
     return { output: r as ExecutionOutput };
+  } catch (e) {
+    return { error: e };
+  }
+}
+
+export async function format_output(raw_markdown: string, block_name: string, output): Promise<BlockExecute> {
+  try {
+    const r = await invoke(TANGLIT_COMMANDS.format_output, { raw_markdown, block_name, output });
+    console.log("RESULT: ", r);
+    return r;
   } catch (e) {
     return { error: e };
   }


### PR DESCRIPTION
**Motivation**

We want to be able to insert the output of the execution of a code block into the markdown in an appropriate format.

**Description**

When clicking the run button next to a code block, a small pop up appears, with a Run button. When we click that button, the output of the run is shown. If we click on Add to markdown, the frontend calls format_output on the backend, passing the output (ExecutionOutput struct), the raw_markdown, and the name of the executed block. The backend returns an "Edit" which has "content" (a string) and a line number where the content should be inserted. The frontend then applies this edit calling the monaco editor api.

I had to add the end line to CodeBlock. And make execute_block return an ExecutionOutput instead of the standard "Output" because we need the Serialize/Deserialize to pass the output from the backend to the frontend, and in this case, from the frontend to the backend.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #82

