### PR TITLE
feat: tangle full document

### DIFF
--- a/backend/src/cli.rs
+++ b/backend/src/cli.rs
@@ -18,6 +18,10 @@ pub enum Commands {
     Execute(ExecuteArgs),
     #[command(about = "Generates a PDF from an markdown file, skiping the items with % markers")]
     GeneratePDF(GeneratePDFArgs),
+    #[command(
+        about = "Tangle all code blocks marked for export from a markdown file and export to export files"
+    )]
+    TangleAll(TangleAllArgs),
 }
 
 #[derive(Args, Debug)]
@@ -94,4 +98,18 @@ pub struct GeneratePDFArgs {
         env = "OUTPUT_FILE_PATH"
     )]
     pub output_file_path: String,
+}
+
+#[derive(Args)]
+pub struct TangleAllArgs {
+    #[command(flatten)]
+    pub general: GeneralArgs,
+    #[arg(
+        long,
+        value_name = "OUTPUT_DIR",
+        help = "Path to the directory where the output files will be saved.",
+        help_heading = "Tangle All Args",
+        env = "OUTPUT_DIR"
+    )]
+    pub output_dir: String,
 }

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use serde::Serialize;
 
 const USE_REGEX: &str = r"use=\[([^\]]*)\]";
+const EXPORT_REGEX: &str = r"export\s*=\s*([^\s]+)";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CodeBlock {
@@ -20,6 +21,7 @@ impl CodeBlock {
         code: String,
         tag: String,
         imports: Vec<String>,
+        export: Option<String>,
         start_line: usize,
     ) -> Self {
         Self {
@@ -32,14 +34,14 @@ impl CodeBlock {
     }
 
     pub fn new_with_code(code: String) -> Self {
-        Self::new(None, code, "".to_string(), Vec::new(), 0)
+        Self::new(None, code, "".to_string(), Vec::new(), None, 0)
     }
 
     /// Creates a CodeBlock from a Code node, extracting the language, code, tag, and imports.
     /// If the tag is not specified in the code block, it defaults to the line number of the code block.
     pub fn from_code_node(code_block: Code) -> Result<Self, ParserError> {
         let language = code_block.lang;
-        let (tag, imports) = Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
+        let (tag, imports, export) = Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
         let start_line = code_block
             .position
             .ok_or_else(|| ParserError::CodeBlockError("Block position not found".to_string()))?
@@ -55,11 +57,12 @@ impl CodeBlock {
             code_block.value,
             tag,
             imports,
+            export,
             start_line,
         ))
     }
 
-    fn parse_metadata(metadata: &str) -> (Option<String>, Vec<String>) {
+    fn parse_metadata(metadata: &str) -> (Option<String>, Vec<String>, Option<String>) {
         // Regex to capture `use=[...]`
         let use_re = Regex::new(USE_REGEX).expect("Failed to compile USE_REGEX");
 
@@ -75,16 +78,25 @@ impl CodeBlock {
             })
             .unwrap_or_default();
 
-        // Remove the `use=[...]` part to get the block tag
-        let metadata_without_use = use_re.replace(metadata, "");
+        // Extract export
+        let export_re = Regex::new(EXPORT_REGEX).expect("Failed to compile EXPORT_REGEX");
+        let export = export_re
+            .captures(metadata)
+            .map(|caps| caps[1].to_string());
 
-        // Take the first word that is not part of `use=` as the tag
-        let tag = metadata_without_use
+
+        // Remove the `use=[...]` and `export=` part to get the block tag
+        let metadata_without_use = use_re.replace(metadata, "");
+        let metadata_clean = export_re.replace(&metadata_without_use, "");
+
+
+        // Take the first word that is not part of `use=` and `export=` as the tag
+        let tag = metadata_clean
             .split_whitespace()
             .next()
             .map(|s| s.to_string());
 
-        (tag, imports)
+        (tag, imports, export)
     }
 }
 
@@ -95,15 +107,15 @@ mod tests {
     #[test]
     fn test_parse_metadata_with_use() {
         let metadata = "use=[block1,block2] tag1";
-        let (tag, imports) = CodeBlock::parse_metadata(metadata);
+        let (tag, imports, _) = CodeBlock::parse_metadata(metadata);
         assert_eq!(tag, Some("tag1".to_string()));
         assert_eq!(imports, vec!["block1".to_string(), "block2".to_string()]);
     }
 
     #[test]
-    fn test_parse_metadata_without_use() {
+    fn test_parse_metadata_with_only_tag() {
         let metadata = "tag2";
-        let (tag, imports) = CodeBlock::parse_metadata(metadata);
+        let (tag, imports, _) = CodeBlock::parse_metadata(metadata);
         assert_eq!(tag, Some("tag2".to_string()));
         assert!(imports.is_empty());
     }
@@ -111,8 +123,35 @@ mod tests {
     #[test]
     fn test_parse_metadata_empty() {
         let metadata = "";
-        let (tag, imports) = CodeBlock::parse_metadata(metadata);
+        let (tag, imports, _) = CodeBlock::parse_metadata(metadata);
         assert!(tag.is_none());
         assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_parse_metadata_with_export_and_tag() {
+        let metadata = "export=main.c tag3";
+        let (tag, imports, export) = CodeBlock::parse_metadata(metadata);
+        assert_eq!(tag, Some("tag3".to_string()));
+        assert!(imports.is_empty());
+        assert_eq!(export, Some("main.c".to_string()));
+    }
+
+    #[test]
+    fn test_parse_metadata_with_use_and_export() {
+        let metadata = "use=[block1, block2] export=main.c";
+        let (tag, imports, export) = CodeBlock::parse_metadata(metadata);
+        assert!(tag.is_none());
+        assert_eq!(imports, vec!["block1".to_string(), "block2".to_string()]);
+        assert_eq!(export, Some("main.c".to_string()));
+    }
+
+    #[test]
+    fn test_parse_metadata_with_use_export_and_tag() {
+        let metadata = "use=[block1] export=main.c tag4";
+        let (tag, imports, export) = CodeBlock::parse_metadata(metadata);
+        assert_eq!(tag, Some("tag4".to_string()));
+        assert_eq!(imports, vec!["block1".to_string()]);
+        assert_eq!(export, Some("main.c".to_string()));
     }
 }

--- a/backend/src/doc/parser/code_block.rs
+++ b/backend/src/doc/parser/code_block.rs
@@ -12,6 +12,7 @@ pub struct CodeBlock {
     pub code: String,
     pub tag: String,
     pub imports: Vec<String>,
+    pub export: Option<String>,
     pub start_line: usize,
 }
 
@@ -29,6 +30,7 @@ impl CodeBlock {
             code,
             tag,
             imports,
+            export,
             start_line,
         }
     }
@@ -41,7 +43,8 @@ impl CodeBlock {
     /// If the tag is not specified in the code block, it defaults to the line number of the code block.
     pub fn from_code_node(code_block: Code) -> Result<Self, ParserError> {
         let language = code_block.lang;
-        let (tag, imports, export) = Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
+        let (tag, imports, export) =
+            Self::parse_metadata(code_block.meta.unwrap_or_default().as_str());
         let start_line = code_block
             .position
             .ok_or_else(|| ParserError::CodeBlockError("Block position not found".to_string()))?
@@ -80,15 +83,11 @@ impl CodeBlock {
 
         // Extract export
         let export_re = Regex::new(EXPORT_REGEX).expect("Failed to compile EXPORT_REGEX");
-        let export = export_re
-            .captures(metadata)
-            .map(|caps| caps[1].to_string());
-
+        let export = export_re.captures(metadata).map(|caps| caps[1].to_string());
 
         // Remove the `use=[...]` and `export=` part to get the block tag
         let metadata_without_use = use_re.replace(metadata, "");
         let metadata_clean = export_re.replace(&metadata_without_use, "");
-
 
         // Take the first word that is not part of `use=` and `export=` as the tag
         let tag = metadata_clean

--- a/backend/src/doc/tangle.rs
+++ b/backend/src/doc/tangle.rs
@@ -88,6 +88,13 @@ impl CodeBlocks {
     pub fn get_block(&self, name: &str) -> Option<&CodeBlock> {
         self.blocks.get(name)
     }
+
+    pub fn get_all_blocks_to_tangle(&self) -> Vec<&CodeBlock> {
+        self.blocks
+            .values()
+            .filter(|block| block.export.is_some())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/doc/tangle.rs
+++ b/backend/src/doc/tangle.rs
@@ -105,6 +105,7 @@ mod tests {
                 "print('Hello, world!')".to_string(),
                 "main".to_string(),
                 vec!["helper".to_string()],
+                None,
                 0,
             ),
         );
@@ -115,6 +116,7 @@ mod tests {
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                None,
                 0,
             ),
         );
@@ -138,6 +140,7 @@ mod tests {
                 "print('Hello, world!')".to_string(),
                 "main".to_string(),
                 vec!["helper".to_string()],
+                None,
                 0,
             ),
         );
@@ -156,6 +159,7 @@ mod tests {
             "@[helper]\nprint('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],
+            None,
             0,
         );
         blocks.insert("main".to_string(), main.clone());
@@ -166,6 +170,7 @@ mod tests {
                 "print('Helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                None,
                 0,
             ),
         );
@@ -189,6 +194,7 @@ mod tests {
             "@[helper]\nprint('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],
+            None,
             0,
         );
         blocks.insert("main".to_string(), main.clone());
@@ -213,6 +219,7 @@ mod tests {
             "for i in range(2):\n    @[helper]\n    print('Hello, world!')".to_string(),
             "main".to_string(),
             vec![],
+            None,
             0,
         );
         blocks.insert("main".to_string(), main.clone());
@@ -223,6 +230,7 @@ mod tests {
                 "print('Helper function')\nprint('second helper function')".to_string(),
                 "helper".to_string(),
                 vec![],
+                None,
                 0,
             ),
         );

--- a/backend/src/execution/wrappers.rs
+++ b/backend/src/execution/wrappers.rs
@@ -120,6 +120,7 @@ mod tests {
             "@[x]\nprintf(\"Hello, world!: %d\",x);".to_string(),
             "main".to_string(),
             vec!["io".to_string()],
+            None,
             0,
         );
         blocks.insert("main".to_string(), main.clone());
@@ -130,6 +131,7 @@ mod tests {
                 "#include <stdio.h>".to_string(),
                 "io".to_string(),
                 vec![],
+                None,
                 0,
             ),
         );
@@ -140,6 +142,7 @@ mod tests {
                 "int x;\nx = 42;".to_string(),
                 "x".to_string(),
                 vec![],
+                None,
                 0,
             ),
         );

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,6 @@
-use backend::cli::{Commands, ExcludeArgs, GeneratePDFArgs, GenerateSlidesMdArgs, TangleArgs, TangleAllArgs};
+use backend::cli::{
+    Commands, ExcludeArgs, GeneratePDFArgs, GenerateSlidesMdArgs, TangleAllArgs, TangleArgs,
+};
 use backend::configuration::{get_config_for_lang, init_configuration};
 use backend::doc::{TangleError, TanglitDoc};
 use backend::errors::ExecutionError;
@@ -124,7 +126,6 @@ fn handle_generate_md_slides(args: GenerateSlidesMdArgs) -> Result<String, Execu
     doc.generate_md_slides(args.output_dir)?;
 
     Ok("✅ Slides Generated".to_string())
-
 }
 
 fn main() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -84,9 +84,7 @@ fn handle_generate_pdf_command(
     ))
 }
 
-fn handle_tangle_all_command(
-    tangle_all_command: TangleAllArgs,
-) -> Result<String, ExecutionError> {
+fn handle_tangle_all_command(tangle_all_command: TangleAllArgs) -> Result<String, ExecutionError> {
     let input_file_path = &tangle_all_command.general.input_file_path;
     let doc = TanglitDoc::new_from_file(input_file_path)?;
 
@@ -102,10 +100,7 @@ fn handle_tangle_all_command(
             .and_then(|l| get_config_for_lang(l).ok())
             .and_then(|cfg| cfg.extension);
 
-        let file_name = block
-            .export
-            .clone()
-            .unwrap_or(block.tag.clone());
+        let file_name = block.export.clone().unwrap_or(block.tag.clone());
 
         // Manejo de error simple
         write_file(
@@ -123,7 +118,6 @@ fn handle_tangle_all_command(
         tangle_all_command.output_dir
     ))
 }
-
 
 fn main() {
     init(); // Initialize the logger


### PR DESCRIPTION
**Motivation**

Until now, tangling was only possible for individual code blocks. This limitation becomes problematic in documents where multiple blocks need to be exported simultaneously, as it forces users to repeat the process manually for each block.  
This feature allows running `tangle` on the entire file at once, simplifying the workflow and ensuring all exported blocks are written in a single step.

**Description**

This PR introduces the `tangle all` command, which processes every exportable code block in the document.  
- Iterates through all code blocks with an `export` tag.  
- Writes the tangled output to the configured directory.  
- Stops and reports detailed errors if any block fails to be written.  
- On success, reports the total number of tangled blocks and the output directory.

