### PR TITLE
feat: add generate-html command to the CLI

### DIFF
--- a/backend/src/cli.rs
+++ b/backend/src/cli.rs
@@ -16,8 +16,10 @@ pub enum Commands {
     Exclude(ExcludeArgs),
     #[command(about = "Execute a specific code block from a markdown file and read its output")]
     Execute(ExecuteArgs),
-    #[command(about = "Generates a PDF from an markdown file, skiping the items with % markers")]
-    GeneratePDF(GeneratePDFArgs),
+    #[command(about = "Generates a PDF from an markdown file, skipping the items with % markers")]
+    GeneratePDF(GenerateDocArgs),
+    #[command(about = "Generates an HTML from an markdown file, skipping the items with % markers")]
+    GenerateHTML(GenerateDocArgs),
     #[command(about = "Generates markdown slides from a markdown file")]
     GenerateSlidesMd(GenerateSlidesMdArgs),
 }
@@ -85,7 +87,7 @@ pub struct ExecuteArgs {
 }
 
 #[derive(Args)]
-pub struct GeneratePDFArgs {
+pub struct GenerateDocArgs {
     #[command(flatten)]
     pub general: GeneralArgs,
     #[arg(

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -1,13 +1,13 @@
 mod error;
+mod gen_html;
 mod generate_pdf;
 mod parser;
 mod tangle;
 
+use crate::doc::gen_html::markdown_to_html;
 use crate::doc::generate_pdf::generate_pdf;
 use crate::doc::parser::slides::parse_slides_from_ast;
-use crate::doc::parser::{
-    ast_to_markdown, markdown_to_html, parse_code_blocks_from_ast, parse_from_string,
-};
+use crate::doc::parser::{ast_to_markdown, parse_code_blocks_from_ast, parse_from_string};
 pub use error::DocError;
 use markdown::mdast::Node;
 pub use parser::ParserError;

--- a/backend/src/doc/gen_html.rs
+++ b/backend/src/doc/gen_html.rs
@@ -1,0 +1,64 @@
+use comrak::plugins::syntect::SyntectAdapterBuilder;
+use comrak::{Plugins, markdown_to_html_with_plugins};
+
+// Taken from https://github.com/sindresorhus/github-markdown-css/blob/bedb4b771f5fa1ae117df597c79993fd1eb4dff0/github-markdown-light.css
+const GITHUB_MARKDOWN_LIGHT_CSS: &str = include_str!("../../resources/github-markdown-light.css");
+
+// TODO: Make all options configurable
+pub fn markdown_to_html(input: &str) -> String {
+    // InspiredGitHub
+    // Solarized (dark)
+    // Solarized (light)
+    // base16-eighties.dark
+    // base16-mocha.dark
+    // base16-ocean.dark
+    // base16-ocean.light
+    let adapter = SyntectAdapterBuilder::new()
+        .theme("base16-ocean.light")
+        .build();
+
+    let mut options = comrak::Options::default();
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.tagfilter = true;
+    options.extension.tasklist = true;
+    options.extension.autolink = true;
+    options.extension.footnotes = true;
+    options.extension.header_ids = Some("user-content-".to_string()); // mimics GitHub's prefix
+    options.render.github_pre_lang = true;
+
+    let mut plugins = Plugins::default();
+
+    plugins.render.codefence_syntax_highlighter = Some(&adapter);
+
+    let inner_html = markdown_to_html_with_plugins(input, &options, &plugins);
+
+    let content_html = format!(r#"<div class="markdown-body">{inner_html}</div>"#);
+
+    wrap_in_html_doc(
+        &content_html,
+        "Document", // TODO get title from arg or extract from markdown
+        &[GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
+    )
+}
+
+/// Wraps an HTML fragment in a complete HTML5 document shell.
+fn wrap_in_html_doc(content: &str, title: &str, styles: &[String]) -> String {
+    let style_tags: String = styles
+        .iter()
+        .map(|s| format!(r#"<style>{}</style>"#, s))
+        .collect();
+    format!(
+        r#"<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>{title}</title>
+                {style_tags}
+            </head>
+            <body>
+                {content}
+            </body>
+            </html>"#
+    )
+}

--- a/backend/src/doc/parser.rs
+++ b/backend/src/doc/parser.rs
@@ -131,9 +131,34 @@ pub fn markdown_to_html(input: &str) -> String {
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
     let inner_html = markdown_to_html_with_plugins(input, &options, &plugins);
+
+    let content_html = format!(r#"<div class="markdown-body">{inner_html}</div>"#);
+
+    wrap_in_html_doc(
+        &content_html,
+        "Document",
+        vec![GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
+    )
+}
+
+/// Wraps an HTML fragment in a complete HTML5 document shell.
+fn wrap_in_html_doc(content: &str, title: &str, styles: Vec<String>) -> String {
+    let style_tags: String = styles
+        .into_iter()
+        .map(|s| format!(r#"<style>{}</style>"#, s))
+        .collect();
     format!(
-        r#"<style>{}</style><div class="markdown-body">{}</div>"#,
-        GITHUB_MARKDOWN_LIGHT_CSS, inner_html
+        r#"<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>{title}</title>
+                {style_tags}
+            </head>
+            <body>
+                {content}
+            </body>
+            </html>"#
     )
 }
 

--- a/backend/src/doc/parser.rs
+++ b/backend/src/doc/parser.rs
@@ -137,14 +137,14 @@ pub fn markdown_to_html(input: &str) -> String {
     wrap_in_html_doc(
         &content_html,
         "Document", // TODO get title from arg or extract from markdown
-        vec![GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
+        &[GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
     )
 }
 
 /// Wraps an HTML fragment in a complete HTML5 document shell.
-fn wrap_in_html_doc(content: &str, title: &str, styles: Vec<String>) -> String {
+fn wrap_in_html_doc(content: &str, title: &str, styles: &[String]) -> String {
     let style_tags: String = styles
-        .into_iter()
+        .iter()
         .map(|s| format!(r#"<style>{}</style>"#, s))
         .collect();
     format!(

--- a/backend/src/doc/parser.rs
+++ b/backend/src/doc/parser.rs
@@ -3,16 +3,12 @@ pub mod exclude;
 pub mod slides;
 
 use code_block::CodeBlock;
-use comrak::{Plugins, markdown_to_html_with_plugins, plugins::syntect::SyntectAdapterBuilder};
 use markdown::{
     ParseOptions,
     mdast::{Code, Node},
 };
 use std::collections::HashMap;
 use std::fmt;
-
-// Taken from https://github.com/sindresorhus/github-markdown-css/blob/bedb4b771f5fa1ae117df597c79993fd1eb4dff0/github-markdown-light.css
-const GITHUB_MARKDOWN_LIGHT_CSS: &str = include_str!("../../resources/github-markdown-light.css");
 
 pub enum ParserError {
     InvalidInput(String),
@@ -101,65 +97,6 @@ fn get_code_nodes_from_mdast(mdast: &Node) -> Result<Vec<Code>, ParserError> {
         }
     }
     Ok(code_nodes)
-}
-
-// TODO: Make all options configurable
-pub fn markdown_to_html(input: &str) -> String {
-    // InspiredGitHub
-    // Solarized (dark)
-    // Solarized (light)
-    // base16-eighties.dark
-    // base16-mocha.dark
-    // base16-ocean.dark
-    // base16-ocean.light
-    let adapter = SyntectAdapterBuilder::new()
-        .theme("base16-ocean.light")
-        .build();
-
-    let mut options = comrak::Options::default();
-    options.extension.strikethrough = true;
-    options.extension.table = true;
-    options.extension.tagfilter = true;
-    options.extension.tasklist = true;
-    options.extension.autolink = true;
-    options.extension.footnotes = true;
-    options.extension.header_ids = Some("user-content-".to_string()); // mimics GitHub's prefix
-    options.render.github_pre_lang = true;
-
-    let mut plugins = Plugins::default();
-
-    plugins.render.codefence_syntax_highlighter = Some(&adapter);
-
-    let inner_html = markdown_to_html_with_plugins(input, &options, &plugins);
-
-    let content_html = format!(r#"<div class="markdown-body">{inner_html}</div>"#);
-
-    wrap_in_html_doc(
-        &content_html,
-        "Document", // TODO get title from arg or extract from markdown
-        &[GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
-    )
-}
-
-/// Wraps an HTML fragment in a complete HTML5 document shell.
-fn wrap_in_html_doc(content: &str, title: &str, styles: &[String]) -> String {
-    let style_tags: String = styles
-        .iter()
-        .map(|s| format!(r#"<style>{}</style>"#, s))
-        .collect();
-    format!(
-        r#"<!DOCTYPE html>
-            <html lang="en">
-            <head>
-                <meta charset="UTF-8">
-                <title>{title}</title>
-                {style_tags}
-            </head>
-            <body>
-                {content}
-            </body>
-            </html>"#
-    )
 }
 
 #[cfg(test)]

--- a/backend/src/doc/parser.rs
+++ b/backend/src/doc/parser.rs
@@ -136,7 +136,7 @@ pub fn markdown_to_html(input: &str) -> String {
 
     wrap_in_html_doc(
         &content_html,
-        "Document",
+        "Document", // TODO get title from arg or extract from markdown
         vec![GITHUB_MARKDOWN_LIGHT_CSS.to_string()],
     )
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,4 @@
-use backend::cli::{Commands, ExcludeArgs, GeneratePDFArgs, GenerateSlidesMdArgs, TangleArgs};
+use backend::cli::{Commands, ExcludeArgs, GenerateDocArgs, GenerateSlidesMdArgs, TangleArgs};
 use backend::configuration::init_configuration;
 use backend::configuration::language_config::LanguageConfig;
 use backend::doc::{TangleError, TanglitDoc};
@@ -75,8 +75,23 @@ fn handle_execute_command(
     ))
 }
 
+fn handle_generate_html_command(
+    generate_html_args: GenerateDocArgs,
+) -> Result<String, ExecutionError> {
+    let doc = TanglitDoc::new_from_file(&generate_html_args.general.input_file_path)?;
+    let html = doc.generate_html()?;
+
+    match write(Path::new(&generate_html_args.output_file_path), html) {
+        Ok(_) => Ok(format!(
+            "✅ HTML saved to {}",
+            generate_html_args.output_file_path
+        )),
+        Err(e) => Err(WriteError(format!("Error writing to file: {}", e))),
+    }
+}
+
 fn handle_generate_pdf_command(
-    generate_pdf_args: GeneratePDFArgs,
+    generate_pdf_args: GenerateDocArgs,
 ) -> Result<String, ExecutionError> {
     let doc = TanglitDoc::new_from_file(&generate_pdf_args.general.input_file_path)?;
     doc.generate_pdf(&generate_pdf_args.output_file_path)?;
@@ -109,6 +124,7 @@ fn main() {
         Commands::Exclude(args) => handle_exclude_command(args),
         Commands::Execute(args) => handle_execute_command(args),
         Commands::GeneratePDF(args) => handle_generate_pdf_command(args),
+        Commands::GenerateHTML(args) => handle_generate_html_command(args),
         Commands::GenerateSlidesMd(args) => handle_generate_md_slides(args),
     };
     match result {


### PR DESCRIPTION
**Motivation**

Add a cmd to generate an HTML from the CLI (instead of a PDF)

**Description**

Changed `GeneratePdfArgs` to `GenerateDocArgs` as both gen-pdf and gen-html commands take the same args (we might make it a single cmd in the future). Also made `markdown_to_html` return a full html documents, with `doctype`, `html`, `head`, `body` tags that were missing. Moved `markdown_to_html` to `gen_html` module inside `doc`.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes #96

