### PR TITLE
feat: nicer error when config not found for a language

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -71,7 +71,7 @@ impl From<ConfigError> for ExecutionError {
 pub enum ConfigError {
     IoError(String),
     ParseError(String),
-    NotFound(String),
+    ConfigMissingForLanguage(String, String),
     InternalError(String),
 }
 impl fmt::Display for ConfigError {
@@ -79,7 +79,11 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::IoError(msg) => write!(f, "I/O error: {}", msg),
             ConfigError::ParseError(msg) => write!(f, "Parse error: {}", msg),
-            ConfigError::NotFound(msg) => write!(f, "Not found: {}", msg),
+            ConfigError::ConfigMissingForLanguage(lang, path) => write!(
+                f,
+                "Config missing for language '{}', expected at path '{}'",
+                lang, path
+            ),
             ConfigError::InternalError(msg) => write!(f, "Internal error: {}", msg),
         }
     }
@@ -102,7 +106,11 @@ impl fmt::Debug for ConfigError {
         match self {
             ConfigError::IoError(msg) => write!(f, "I/O error: {}", msg),
             ConfigError::ParseError(msg) => write!(f, "Parse error: {}", msg),
-            ConfigError::NotFound(msg) => write!(f, "Not found: {}", msg),
+            ConfigError::ConfigMissingForLanguage(lang, path) => write!(
+                f,
+                "Config missing for language '{}', expected at path '{}'",
+                lang, path
+            ),
             ConfigError::InternalError(msg) => write!(f, "Internal error: {}", msg),
         }
     }

--- a/backend/test_data/test_file.md
+++ b/backend/test_data/test_file.md
@@ -22,6 +22,12 @@ for i in range(4):
     print(a)
 ```
 
+```noconfiglang foo
+a = 'SPAM'
+for i in range(4):
+    print(a)
+```
+
 Define main block `run`:
 
 ```c use=[headers,helper] main_block


### PR DESCRIPTION
**Motivation**

Instead of raising an IO error in this case, show a clearer error.

**Description**

Change `ConfigError::NotFound` (not used anywhere else) to `ConfigMissingForLanguage` and raise that error if the expected path for the config of that language is not found.

<!-- Link to issues: Closes #111, Closes #222 -->

Closes None

