### PR TITLE
fix: native addon loading for published extension

### DIFF
--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,6 @@
+**/*
+!out/**
+!native/*.node
+!icon.png
+!package.json
+!LICENSE

--- a/vscode-extension/LICENSE
+++ b/vscode-extension/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TP-FIUBA-133
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vscode-extension/src/tanglit.ts
+++ b/vscode-extension/src/tanglit.ts
@@ -1,6 +1,33 @@
 // Native addon bindings for the tanglit Rust backend
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const native = require("../native/tanglit.node");
+// Load the platform-specific native addon
+// Local dev builds produce tanglit.node, CI builds produce tanglit.<platform>.node
+import * as os from "os";
+import * as path from "path";
+
+function loadNativeAddon() {
+  const nativeDir = path.join(__dirname, "..", "native");
+  // Try the generic name first (local dev builds)
+  try {
+    return require(path.join(nativeDir, "tanglit.node"));
+  } catch {
+    // Fall back to platform-specific name (CI builds)
+    const platform = os.platform();
+    const arch = os.arch();
+    const platformMap: Record<string, string> = {
+      "darwin-arm64": "tanglit.darwin-arm64.node",
+      "darwin-x64": "tanglit.darwin-x64.node",
+      "linux-x64": "tanglit.linux-x64-gnu.node",
+      "win32-x64": "tanglit.win32-x64-msvc.node",
+    };
+    const filename = platformMap[`${platform}-${arch}`];
+    if (!filename) {
+      throw new Error(`Unsupported platform: ${platform}-${arch}`);
+    }
+    return require(path.join(nativeDir, filename));
+  }
+}
+
+const native = loadNativeAddon();
 
 export interface CodeBlock {
   tag: string;


### PR DESCRIPTION
**Motivation**

The published VS Code extension fails to activate because the native addon file can't be found. CI builds produce platform-specific filenames (`tanglit.darwin-arm64.node`, etc.) but the code was hardcoded to `require("../native/tanglit.node")`.

**Description**

- Update `tanglit.ts` to try the generic filename first (local dev), then fall back to platform-specific names based on `os.platform()` and `os.arch()`
- Add `.vscodeignore` to only include needed files in the `.vsix` package
- Copy `LICENSE` into the extension directory for Marketplace compliance

Closes None